### PR TITLE
new domain for wikia -> fandom

### DIFF
--- a/vc.json
+++ b/vc.json
@@ -10,7 +10,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5b/Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alchemist"
       },
       {
         "name": "Andromeda",
@@ -23,7 +23,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e6/Andromeda.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Andromeda"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Andromeda"
       },
       {
         "name": "Angel of Love",
@@ -36,7 +36,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/43/Angel_of_Love.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angel_of_Love"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angel_of_Love"
       },
       {
         "name": "Artist",
@@ -49,7 +49,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Artist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Artist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Artist"
       },
       {
         "name": "Athlete",
@@ -62,7 +62,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f3/Athlete.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Athlete"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Athlete"
       },
       {
         "name": "Balloon Artist",
@@ -75,7 +75,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c9/Balloon_Artist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balloon_Artist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balloon_Artist"
       },
       {
         "name": "Beleth",
@@ -88,7 +88,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8e/Beleth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beleth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beleth"
       },
       {
         "name": "Beriatan",
@@ -101,7 +101,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/52/Beriatan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beriatan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beriatan"
       },
       {
         "name": "Bird-of-Paradise",
@@ -114,7 +114,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/39/Bird-of-Paradise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bird-of-Paradise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bird-of-Paradise"
       },
       {
         "name": "Black Cat",
@@ -127,7 +127,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cf/Black_Cat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Cat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Cat"
       },
       {
         "name": "Blacksmith",
@@ -140,7 +140,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/be/Blacksmith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blacksmith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blacksmith"
       },
       {
         "name": "Bloodshed",
@@ -153,7 +153,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/47/Bloodshed.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bloodshed"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bloodshed"
       },
       {
         "name": "Brownie",
@@ -166,7 +166,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/25/Brownie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brownie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brownie"
       },
       {
         "name": "Bullet Girl",
@@ -179,7 +179,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/de/Bullet_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bullet_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bullet_Girl"
       },
       {
         "name": "Cait Sith",
@@ -192,7 +192,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6d/Cait_Sith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cait_Sith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cait_Sith"
       },
       {
         "name": "Calypso",
@@ -205,7 +205,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/59/Calypso.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Calypso"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Calypso"
       },
       {
         "name": "Candy Apple",
@@ -218,7 +218,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2e/Candy_Apple.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Candy_Apple"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Candy_Apple"
       },
       {
         "name": "Canopus",
@@ -231,7 +231,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/13/Canopus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Canopus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Canopus"
       },
       {
         "name": "Casino Waitress",
@@ -244,7 +244,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d5/Casino_Waitress.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Casino_Waitress"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Casino_Waitress"
       },
       {
         "name": "Chocolat",
@@ -257,7 +257,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/78/Chocolat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocolat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocolat"
       },
       {
         "name": "Chocowhip",
@@ -270,7 +270,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e5/Chocowhip.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocowhip"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocowhip"
       },
       {
         "name": "Corona",
@@ -283,7 +283,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bd/Corona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Corona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Corona"
       },
       {
         "name": "Cosmos",
@@ -296,7 +296,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/64/Cosmos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cosmos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cosmos"
       },
       {
         "name": "Death Lord",
@@ -309,7 +309,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5a/Death_Lord.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Death_Lord"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Death_Lord"
       },
       {
         "name": "Delivery Girl",
@@ -322,7 +322,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0f/Delivery_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Delivery_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Delivery_Girl"
       },
       {
         "name": "Delphinus",
@@ -335,7 +335,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2f/Delphinus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Delphinus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Delphinus"
       },
       {
         "name": "Demon Twins",
@@ -348,7 +348,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f2/Demon_Twins.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demon_Twins"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demon_Twins"
       },
       {
         "name": "Devil Hunter",
@@ -361,7 +361,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/68/Devil_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Devil_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Devil_Hunter"
       },
       {
         "name": "Dice",
@@ -374,7 +374,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4c/Dice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dice"
       },
       {
         "name": "Doggy Detective",
@@ -387,7 +387,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/22/Doggy_Detective.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doggy_Detective"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doggy_Detective"
       },
       {
         "name": "Doppelganger",
@@ -400,7 +400,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/75/Doppelganger.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doppelganger"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doppelganger"
       },
       {
         "name": "Dragon Master",
@@ -413,7 +413,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d8/Dragon_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dragon_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dragon_Master"
       },
       {
         "name": "Dragonewt",
@@ -426,7 +426,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3a/Dragonewt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dragonewt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dragonewt"
       },
       {
         "name": "Esper",
@@ -439,7 +439,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/64/Esper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Esper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Esper"
       },
       {
         "name": "Farmer",
@@ -452,7 +452,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3d/Farmer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Farmer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Farmer"
       },
       {
         "name": "Flag Girl",
@@ -465,7 +465,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1c/Flag_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flag_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flag_Girl"
       },
       {
         "name": "Fungus",
@@ -478,7 +478,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/50/Fungus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fungus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fungus"
       },
       {
         "name": "Furinkazan",
@@ -491,7 +491,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2e/Furinkazan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furinkazan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furinkazan"
       },
       {
         "name": "Furry",
@@ -504,7 +504,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fa/Furry.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furry"
       },
       {
         "name": "Gate Keeper",
@@ -517,7 +517,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/36/Gate_Keeper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gate_Keeper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gate_Keeper"
       },
       {
         "name": "Gladiator",
@@ -530,7 +530,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/44/Gladiator.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gladiator"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gladiator"
       },
       {
         "name": "Gold Demon",
@@ -543,7 +543,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c1/Gold_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gold_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gold_Demon"
       },
       {
         "name": "Grappler",
@@ -556,7 +556,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/50/Grappler_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Grappler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Grappler"
       },
       {
         "name": "Grenadier",
@@ -569,7 +569,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Grenadier.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Grenadier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Grenadier"
       },
       {
         "name": "Gunner",
@@ -582,7 +582,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d0/Gunner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gunner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gunner"
       },
       {
         "name": "Halfelf",
@@ -595,7 +595,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/99/Halfelf.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Halfelf"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Halfelf"
       },
       {
         "name": "High Pixie",
@@ -608,7 +608,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/34/High_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/High_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/High_Pixie"
       },
       {
         "name": "Hinnagami",
@@ -621,7 +621,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ab/Hinnagami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hinnagami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hinnagami"
       },
       {
         "name": "Home Run",
@@ -634,7 +634,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/11/Home_Run.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Home_Run"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Home_Run"
       },
       {
         "name": "Ichikishimahime",
@@ -647,7 +647,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/65/Ichikishimahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ichikishimahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ichikishimahime"
       },
       {
         "name": "Illusionist",
@@ -660,7 +660,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/af/Illusionist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Illusionist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Illusionist"
       },
       {
         "name": "Jiang Shi",
@@ -673,7 +673,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/43/Jiang_Shi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jiang_Shi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jiang_Shi"
       },
       {
         "name": "Jordi",
@@ -686,7 +686,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/35/Jordi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jordi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jordi"
       },
       {
         "name": "Juice Box",
@@ -699,7 +699,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b0/Juice_Box.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Juice_Box"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Juice_Box"
       },
       {
         "name": "Kogarashi",
@@ -712,7 +712,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bc/Kogarashi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kogarashi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kogarashi"
       },
       {
         "name": "Kraken",
@@ -725,7 +725,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d3/Kraken.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kraken"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kraken"
       },
       {
         "name": "Kung-Fu Master",
@@ -738,7 +738,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/51/Kung-Fu_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kung-Fu_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kung-Fu_Master"
       },
       {
         "name": "Lady Tiger",
@@ -751,7 +751,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4f/Lady_Tiger.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lady_Tiger"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lady_Tiger"
       },
       {
         "name": "Ladybird",
@@ -764,7 +764,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ed/Ladybird.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ladybird"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ladybird"
       },
       {
         "name": "Leananshee",
@@ -777,7 +777,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/ca/Leananshee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leananshee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leananshee"
       },
       {
         "name": "Leo",
@@ -790,7 +790,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1d/Leo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leo"
       },
       {
         "name": "Little Turkey",
@@ -803,7 +803,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e9/Little_Turkey.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Turkey"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Turkey"
       },
       {
         "name": "Lucky Cat",
@@ -816,7 +816,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f1/Lucky_Cat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucky_Cat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucky_Cat"
       },
       {
         "name": "Maestro",
@@ -829,7 +829,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fa/Maestro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maestro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maestro"
       },
       {
         "name": "Maid",
@@ -842,7 +842,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2a/Maid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maid"
       },
       {
         "name": "Martial Artist",
@@ -855,7 +855,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a7/Martial_Artist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Martial_Artist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Martial_Artist"
       },
       {
         "name": "Masquerade",
@@ -868,7 +868,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a4/Masquerade.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Masquerade"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Masquerade"
       },
       {
         "name": "Medici",
@@ -881,7 +881,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/db/Medici.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medici"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medici"
       },
       {
         "name": "Medusa",
@@ -894,7 +894,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c3/Medusa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medusa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medusa"
       },
       {
         "name": "Melanippe",
@@ -907,7 +907,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/30/Melanippe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melanippe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melanippe"
       },
       {
         "name": "Melete",
@@ -920,7 +920,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4b/Melete.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melete"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melete"
       },
       {
         "name": "Mermaid",
@@ -933,7 +933,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/66/Mermaid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mermaid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mermaid"
       },
       {
         "name": "Mika In Training",
@@ -946,7 +946,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/87/Mika_In_Training.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mika_In_Training"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mika_In_Training"
       },
       {
         "name": "Millionaire",
@@ -959,7 +959,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/75/Millionaire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Millionaire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Millionaire"
       },
       {
         "name": "Monkey Master",
@@ -972,7 +972,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/81/Monkey_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Monkey_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Monkey_Master"
       },
       {
         "name": "Nekomata",
@@ -985,7 +985,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/77/Nekomata.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nekomata"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nekomata"
       },
       {
         "name": "Ninjya Dealer",
@@ -998,7 +998,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8a/Ninjya_Dealer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ninjya_Dealer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ninjya_Dealer"
       },
       {
         "name": "Onyankopon",
@@ -1011,7 +1011,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f7/Onyankopon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Onyankopon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Onyankopon"
       },
       {
         "name": "Party Popper",
@@ -1024,7 +1024,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e3/Party_Popper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Party_Popper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Party_Popper"
       },
       {
         "name": "Penguin Girl",
@@ -1037,7 +1037,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0d/Penguin_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Penguin_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Penguin_Girl"
       },
       {
         "name": "Penny-Wise",
@@ -1050,7 +1050,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f7/Penny-Wise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Penny-Wise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Penny-Wise"
       },
       {
         "name": "Peter Pan",
@@ -1063,7 +1063,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4f/Peter_Pan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Peter_Pan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Peter_Pan"
       },
       {
         "name": "Phantom Thief",
@@ -1076,7 +1076,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/70/Phantom_Thief.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Phantom_Thief"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Phantom_Thief"
       },
       {
         "name": "Pinocchio",
@@ -1089,7 +1089,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f5/Pinocchio.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pinocchio"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pinocchio"
       },
       {
         "name": "Police",
@@ -1102,7 +1102,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bf/Police.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Police"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Police"
       },
       {
         "name": "Pub Girl",
@@ -1115,7 +1115,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a5/Pub_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pub_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pub_Girl"
       },
       {
         "name": "Pyromancer",
@@ -1128,7 +1128,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/78/Pyromancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pyromancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pyromancer"
       },
       {
         "name": "Pyrotechnist",
@@ -1141,7 +1141,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/60/Pyrotechnist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pyrotechnist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pyrotechnist"
       },
       {
         "name": "Queen of Fire",
@@ -1154,7 +1154,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/74/Queen_of_Fire_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_of_Fire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_of_Fire"
       },
       {
         "name": "Ratatoskr",
@@ -1167,7 +1167,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c4/Ratatoskr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ratatoskr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ratatoskr"
       },
       {
         "name": "Red Dragon",
@@ -1180,7 +1180,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/95/Red_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Dragon"
       },
       {
         "name": "Rose Knight",
@@ -1193,7 +1193,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/54/Rose_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rose_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rose_Knight"
       },
       {
         "name": "Rotte",
@@ -1206,7 +1206,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/89/Rotte.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rotte"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rotte"
       },
       {
         "name": "Roulette",
@@ -1219,7 +1219,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/11/Roulette.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roulette"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roulette"
       },
       {
         "name": "Runner",
@@ -1232,7 +1232,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/14/Runner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Runner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Runner"
       },
       {
         "name": "Salamander",
@@ -1245,7 +1245,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/53/Salamander.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Salamander"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Salamander"
       },
       {
         "name": "Sally",
@@ -1258,7 +1258,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2e/Sally.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sally"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sally"
       },
       {
         "name": "Scriptwriter",
@@ -1271,7 +1271,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/82/Scriptwriter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scriptwriter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scriptwriter"
       },
       {
         "name": "Sculptor",
@@ -1284,7 +1284,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/53/Sculptor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sculptor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sculptor"
       },
       {
         "name": "Seagull",
@@ -1297,7 +1297,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9a/Seagull.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Seagull"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Seagull"
       },
       {
         "name": "Selene",
@@ -1310,7 +1310,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/36/Selene.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Selene"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Selene"
       },
       {
         "name": "Shisa",
@@ -1323,7 +1323,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/17/Shisa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shisa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shisa"
       },
       {
         "name": "Snowboarder",
@@ -1336,7 +1336,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/15/Snowboarder.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snowboarder"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snowboarder"
       },
       {
         "name": "Soma",
@@ -1349,7 +1349,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bd/Soma.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soma"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soma"
       },
       {
         "name": "Somersault Girl",
@@ -1362,7 +1362,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/af/Somersault_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Somersault_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Somersault_Girl"
       },
       {
         "name": "Sparkles",
@@ -1375,7 +1375,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3d/Sparkles.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sparkles"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sparkles"
       },
       {
         "name": "Sumo Wrestler",
@@ -1388,7 +1388,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/78/Sumo_Wrestler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sumo_Wrestler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sumo_Wrestler"
       },
       {
         "name": "Sun Jian",
@@ -1401,7 +1401,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/aa/Sun_Jian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sun_Jian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sun_Jian"
       },
       {
         "name": "Sunflower",
@@ -1414,7 +1414,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/81/Sunflower.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sunflower"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sunflower"
       },
       {
         "name": "Sword Master",
@@ -1427,7 +1427,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b9/Sword_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sword_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sword_Master"
       },
       {
         "name": "Tanegashima",
@@ -1440,7 +1440,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Tanegashima.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tanegashima"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tanegashima"
       },
       {
         "name": "Tengu",
@@ -1453,7 +1453,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/37/Tengu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tengu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tengu"
       },
       {
         "name": "Thunderbird",
@@ -1466,7 +1466,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3d/Thunderbird.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thunderbird"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thunderbird"
       },
       {
         "name": "Tiamat",
@@ -1479,7 +1479,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Tiamat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tiamat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tiamat"
       },
       {
         "name": "Toyotamahime",
@@ -1492,7 +1492,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/32/Toyotamahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toyotamahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toyotamahime"
       },
       {
         "name": "Urthr",
@@ -1505,7 +1505,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f8/Urthr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Urthr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Urthr"
       },
       {
         "name": "Watermelon",
@@ -1518,7 +1518,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/06/Watermelon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Watermelon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Watermelon"
       },
       {
         "name": "Woodland Guide",
@@ -1531,7 +1531,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3b/Woodland_Guide.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Woodland_Guide"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Woodland_Guide"
       },
       {
         "name": "4th Hammer",
@@ -1548,7 +1548,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/63/4th_Hammer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/4th_Hammer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/4th_Hammer"
       },
       {
         "name": "Accordion",
@@ -1561,7 +1561,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2a/Accordion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Accordion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Accordion"
       },
       {
         "name": "Advent Fairy",
@@ -1574,7 +1574,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/87/Advent_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Advent_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Advent_Fairy"
       },
       {
         "name": "Ai",
@@ -1591,7 +1591,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4d/Ai.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ai"
       },
       {
         "name": "Alchemist Ex",
@@ -1608,7 +1608,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8a/Alchemist_Ex.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alchemist_Ex"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alchemist_Ex"
       },
       {
         "name": "Alice",
@@ -1625,7 +1625,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/82/Alice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alice"
       },
       {
         "name": "Alp",
@@ -1638,7 +1638,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/da/Alp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alp"
       },
       {
         "name": "Amaterasu",
@@ -1655,7 +1655,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e0/Amaterasu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amaterasu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amaterasu"
       },
       {
         "name": "Ame-No-Uzume",
@@ -1672,7 +1672,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3f/Ame-No-Uzume.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ame-No-Uzume"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ame-No-Uzume"
       },
       {
         "name": "Amphis",
@@ -1685,7 +1685,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/82/Amphis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amphis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amphis"
       },
       {
         "name": "Amy",
@@ -1702,7 +1702,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2a/Amy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amy"
       },
       {
         "name": "Anise",
@@ -1719,7 +1719,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fe/Anise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anise"
       },
       {
         "name": "Anna",
@@ -1736,7 +1736,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ae/Anna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anna"
       },
       {
         "name": "Apotheker",
@@ -1749,7 +1749,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/31/Apotheker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Apotheker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Apotheker"
       },
       {
         "name": "Aries",
@@ -1762,7 +1762,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/06/Aries.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aries"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aries"
       },
       {
         "name": "Bacchus",
@@ -1775,7 +1775,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/40/Bacchus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bacchus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bacchus"
       },
       {
         "name": "Baku",
@@ -1792,7 +1792,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bd/Baku.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Baku"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Baku"
       },
       {
         "name": "Bear Hunter",
@@ -1805,7 +1805,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bc/Bear_Hunter_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bear_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bear_Hunter"
       },
       {
         "name": "Beatty",
@@ -1822,7 +1822,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/de/Beatty.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beatty"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beatty"
       },
       {
         "name": "Birthday",
@@ -1835,7 +1835,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8e/Birthday.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Birthday"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Birthday"
       },
       {
         "name": "Black Magic Woman",
@@ -1848,7 +1848,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/85/Black_Magic_Woman.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Magic_Woman"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Magic_Woman"
       },
       {
         "name": "Bloody Mary",
@@ -1865,7 +1865,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b7/Bloody_Mary.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bloody_Mary"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bloody_Mary"
       },
       {
         "name": "Bobbin' Apple",
@@ -1878,7 +1878,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/00/Bobbin%27_Apple.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bobbin%27_Apple"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bobbin%27_Apple"
       },
       {
         "name": "Bran",
@@ -1891,7 +1891,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/90/Bran.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bran"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bran"
       },
       {
         "name": "Brim",
@@ -1904,7 +1904,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/98/Brim.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brim"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brim"
       },
       {
         "name": "Cacao",
@@ -1921,7 +1921,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/60/Cacao.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cacao"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cacao"
       },
       {
         "name": "Cerberus",
@@ -1934,7 +1934,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/45/Cerberus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cerberus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cerberus"
       },
       {
         "name": "Chamuel",
@@ -1951,7 +1951,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/15/Chamuel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chamuel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chamuel"
       },
       {
         "name": "Chocolate Maker",
@@ -1968,7 +1968,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a2/Chocolate_Maker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocolate_Maker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocolate_Maker"
       },
       {
         "name": "Christine",
@@ -1989,7 +1989,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6a/Christine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Christine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Christine"
       },
       {
         "name": "Circe",
@@ -2002,7 +2002,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/75/Circe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Circe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Circe"
       },
       {
         "name": "Cosmonaut",
@@ -2015,7 +2015,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5c/Cosmonaut.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cosmonaut"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cosmonaut"
       },
       {
         "name": "Cthugha",
@@ -2028,7 +2028,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6d/Cthugha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cthugha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cthugha"
       },
       {
         "name": "Cu Chulainn",
@@ -2041,7 +2041,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7a/Cu_Chulainn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cu_Chulainn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cu_Chulainn"
       },
       {
         "name": "Cu Sith",
@@ -2054,7 +2054,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5f/Cu_Sith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cu_Sith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cu_Sith"
       },
       {
         "name": "Cupid",
@@ -2067,7 +2067,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/06/Cupid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cupid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cupid"
       },
       {
         "name": "Curtana",
@@ -2084,7 +2084,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b7/Curtana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Curtana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Curtana"
       },
       {
         "name": "Cybele",
@@ -2097,7 +2097,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f8/Cybele.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cybele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cybele"
       },
       {
         "name": "Dame Ridill",
@@ -2114,7 +2114,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/11/Dame_Ridill_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dame_Ridill"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dame_Ridill"
       },
       {
         "name": "Destroyer",
@@ -2127,7 +2127,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3a/Destroyer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Destroyer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Destroyer"
       },
       {
         "name": "Diana (New)",
@@ -2140,7 +2140,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c1/Diana_%28New%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diana_(New)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diana_(New)"
       },
       {
         "name": "Dr. Mole",
@@ -2157,7 +2157,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3f/Dr._Mole.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dr._Mole"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dr._Mole"
       },
       {
         "name": "Eir",
@@ -2170,7 +2170,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/37/Eir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eir"
       },
       {
         "name": "Eliza",
@@ -2187,7 +2187,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/50/Eliza.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eliza"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eliza"
       },
       {
         "name": "Elsa",
@@ -2200,7 +2200,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4a/Elsa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elsa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elsa"
       },
       {
         "name": "Elune",
@@ -2217,7 +2217,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4e/Elune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elune"
       },
       {
         "name": "Empusa",
@@ -2230,7 +2230,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0a/Empusa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empusa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empusa"
       },
       {
         "name": "Enforcer",
@@ -2247,7 +2247,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e4/Enforcer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Enforcer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Enforcer"
       },
       {
         "name": "Ensemble",
@@ -2264,7 +2264,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/da/Ensemble.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ensemble"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ensemble"
       },
       {
         "name": "Evil Lady",
@@ -2281,7 +2281,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c3/Evil_Lady.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Evil_Lady"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Evil_Lady"
       },
       {
         "name": "Firecracker",
@@ -2298,7 +2298,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/86/Firecracker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Firecracker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Firecracker"
       },
       {
         "name": "Fortuna",
@@ -2315,7 +2315,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/14/Fortuna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fortuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fortuna"
       },
       {
         "name": "Ghostly Anne",
@@ -2328,7 +2328,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d2/Ghostly_Anne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghostly_Anne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghostly_Anne"
       },
       {
         "name": "Green Christmas",
@@ -2341,7 +2341,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f7/Green_Christmas_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Green_Christmas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Green_Christmas"
       },
       {
         "name": "Griffin",
@@ -2366,7 +2366,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f8/Griffin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Griffin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Griffin"
       },
       {
         "name": "Heartthrob",
@@ -2383,7 +2383,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/da/Heartthrob.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Heartthrob"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Heartthrob"
       },
       {
         "name": "Hestia",
@@ -2400,7 +2400,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Hestia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hestia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hestia"
       },
       {
         "name": "Hiderigami",
@@ -2413,7 +2413,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0a/Hiderigami_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hiderigami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hiderigami"
       },
       {
         "name": "Houri",
@@ -2426,7 +2426,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7c/Houri.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Houri"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Houri"
       },
       {
         "name": "Ifrit",
@@ -2439,7 +2439,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b5/Ifrit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ifrit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ifrit"
       },
       {
         "name": "Imoko",
@@ -2452,7 +2452,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/78/Imoko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Imoko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Imoko"
       },
       {
         "name": "Israfil",
@@ -2465,7 +2465,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/29/Israfil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Israfil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Israfil"
       },
       {
         "name": "Izumo No Okuni",
@@ -2482,7 +2482,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/98/Izumo_No_Okuni.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Izumo_No_Okuni"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Izumo_No_Okuni"
       },
       {
         "name": "Jasmine",
@@ -2499,7 +2499,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c1/Jasmine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jasmine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jasmine"
       },
       {
         "name": "Journalist",
@@ -2516,7 +2516,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1e/Journalist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Journalist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Journalist"
       },
       {
         "name": "Junior Director",
@@ -2529,7 +2529,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3c/Junior_Director.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Junior_Director"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Junior_Director"
       },
       {
         "name": "Juvie",
@@ -2542,7 +2542,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/85/Juvie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Juvie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Juvie"
       },
       {
         "name": "Killer Idol",
@@ -2559,7 +2559,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Killer_Idol.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Killer_Idol"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Killer_Idol"
       },
       {
         "name": "Kisaragi",
@@ -2572,7 +2572,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/ba/Kisaragi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kisaragi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kisaragi"
       },
       {
         "name": "Kokkuri Fox",
@@ -2589,7 +2589,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/af/Kokkuri_Fox.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kokkuri_Fox"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kokkuri_Fox"
       },
       {
         "name": "Lamp",
@@ -2602,7 +2602,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/37/Lamp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lamp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lamp"
       },
       {
         "name": "Leto",
@@ -2615,7 +2615,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/de/Leto.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leto"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leto"
       },
       {
         "name": "Little Shion",
@@ -2628,7 +2628,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Little_Shion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Shion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Shion"
       },
       {
         "name": "Livre",
@@ -2641,7 +2641,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/df/Livre.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Livre"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Livre"
       },
       {
         "name": "Lofn",
@@ -2654,7 +2654,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/61/Lofn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lofn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lofn"
       },
       {
         "name": "Lolita Alchemist",
@@ -2667,7 +2667,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/59/Lolita_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lolita_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lolita_Alchemist"
       },
       {
         "name": "Loveberry",
@@ -2680,7 +2680,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/27/Loveberry.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Loveberry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Loveberry"
       },
       {
         "name": "Lucky Ten",
@@ -2693,7 +2693,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/97/Lucky_Ten.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucky_Ten"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucky_Ten"
       },
       {
         "name": "Madre",
@@ -2710,7 +2710,7 @@
         }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c1/Madre.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Madre"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Madre"
       },
       {
         "name": "Maidryl",
@@ -2723,7 +2723,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/30/Maidryl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maidryl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maidryl"
       },
       {
         "name": "Mars",
@@ -2736,7 +2736,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/de/Mars.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mars"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mars"
       },
       {
         "name": "Master Alchemist",
@@ -2749,7 +2749,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6d/Master_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Master_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Master_Alchemist"
       },
       {
         "name": "Matador",
@@ -2762,7 +2762,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ec/Matador.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Matador"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Matador"
       },
       {
         "name": "Mei Mei",
@@ -2775,7 +2775,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8e/Mei_Mei.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mei_Mei"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mei_Mei"
       },
       {
         "name": "Midry",
@@ -2792,7 +2792,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d9/Midry.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Midry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Midry"
       },
       {
         "name": "Mika Live!",
@@ -2805,7 +2805,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b1/Mika_Live%21.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mika_Live!"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mika_Live!"
       },
       {
         "name": "Mnemosyne",
@@ -2818,7 +2818,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/00/Mnemosyne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mnemosyne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mnemosyne"
       },
       {
         "name": "Nami",
@@ -2835,7 +2835,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/dd/Nami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nami"
       },
       {
         "name": "Nezha",
@@ -2848,7 +2848,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a5/Nezha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nezha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nezha"
       },
       {
         "name": "Ninja Master",
@@ -2861,7 +2861,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/79/Ninja_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ninja_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ninja_Master"
       },
       {
         "name": "Nona",
@@ -2874,7 +2874,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/38/Nona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nona"
       },
       {
         "name": "Nova",
@@ -2887,7 +2887,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0b/Nova.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nova"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nova"
       },
       {
         "name": "Nuada",
@@ -2900,7 +2900,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8d/Nuada.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nuada"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nuada"
       },
       {
         "name": "Ogma",
@@ -2917,7 +2917,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e4/Ogma.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ogma"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ogma"
       },
       {
         "name": "Oinari",
@@ -2934,7 +2934,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e9/Oinari.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oinari"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oinari"
       },
       {
         "name": "Omikoshi",
@@ -2951,7 +2951,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b1/Omikoshi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Omikoshi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Omikoshi"
       },
       {
         "name": "Omoikane",
@@ -2976,7 +2976,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/cf/Omoikane.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Omoikane"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Omoikane"
       },
       {
         "name": "Orchestra",
@@ -2989,7 +2989,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d3/Orchestra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Orchestra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Orchestra"
       },
       {
         "name": "Otanukisama",
@@ -3002,7 +3002,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a9/Otanukisama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Otanukisama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Otanukisama"
       },
       {
         "name": "Parade Princess",
@@ -3015,7 +3015,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7e/Parade_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Parade_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Parade_Princess"
       },
       {
         "name": "Passion Fairy",
@@ -3028,7 +3028,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d1/Passion_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Passion_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Passion_Fairy"
       },
       {
         "name": "Patience",
@@ -3045,7 +3045,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bf/Patience.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Patience"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Patience"
       },
       {
         "name": "Pianta",
@@ -3062,7 +3062,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Pianta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pianta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pianta"
       },
       {
         "name": "Pheme",
@@ -3075,7 +3075,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0d/Pheme.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pheme"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pheme"
       },
       {
         "name": "Pigsy",
@@ -3088,7 +3088,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c3/Pigsy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pigsy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pigsy"
       },
       {
         "name": "Poltergeist",
@@ -3105,7 +3105,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bb/Poltergeist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Poltergeist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Poltergeist"
       },
       {
         "name": "Precious Amy",
@@ -3122,7 +3122,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/33/Precious_Amy_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Precious_Amy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Precious_Amy"
       },
       {
         "name": "Princess",
@@ -3135,7 +3135,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f2/Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess"
       },
       {
         "name": "Psyche",
@@ -3148,7 +3148,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a9/Psyche.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Psyche"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Psyche"
       },
       {
         "name": "Pyromaniac",
@@ -3161,7 +3161,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/45/Pyromaniac.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pyromaniac"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pyromaniac"
       },
       {
         "name": "Queen Momo",
@@ -3174,7 +3174,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ea/Queen_Momo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Momo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Momo"
       },
       {
         "name": "Queen of Amazons",
@@ -3187,7 +3187,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f2/Queen_of_Amazons.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_of_Amazons"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_of_Amazons"
       },
       {
         "name": "Ragnarok",
@@ -3200,7 +3200,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/68/Ragnarok.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ragnarok"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ragnarok"
       },
       {
         "name": "Rain Doll",
@@ -3213,7 +3213,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/57/Rain_Doll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rain_Doll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rain_Doll"
       },
       {
         "name": "Reindeer Girl",
@@ -3226,7 +3226,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/57/Reindeer_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Reindeer_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Reindeer_Girl"
       },
       {
         "name": "Ridill",
@@ -3243,7 +3243,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/87/Ridill.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ridill"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ridill"
       },
       {
         "name": "Rokumonsen",
@@ -3260,7 +3260,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1b/Rokumonsen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rokumonsen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rokumonsen"
       },
       {
         "name": "Sacred Fire",
@@ -3273,7 +3273,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/dd/Sacred_Fire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacred_Fire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacred_Fire"
       },
       {
         "name": "Salir",
@@ -3290,7 +3290,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Salir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Salir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Salir"
       },
       {
         "name": "Scathach",
@@ -3303,7 +3303,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/17/Scathach.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scathach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scathach"
       },
       {
         "name": "Scylla",
@@ -3316,7 +3316,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/60/Scylla.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scylla"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scylla"
       },
       {
         "name": "Sgt. Dynamite",
@@ -3333,7 +3333,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f8/Sgt._Dynamite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sgt._Dynamite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sgt._Dynamite"
       },
       {
         "name": "Shogi Master",
@@ -3346,7 +3346,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d8/Shogi_Master_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shogi_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shogi_Master"
       },
       {
         "name": "Shy Sally",
@@ -3359,7 +3359,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/05/Shy_Sally.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shy_Sally"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shy_Sally"
       },
       {
         "name": "Sjofn",
@@ -3372,7 +3372,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e2/Sjofn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sjofn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sjofn"
       },
       {
         "name": "Slider",
@@ -3385,7 +3385,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/04/Slider.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Slider"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Slider"
       },
       {
         "name": "Sophie",
@@ -3398,7 +3398,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/50/Sophie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sophie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sophie"
       },
       {
         "name": "Soul Eater",
@@ -3415,7 +3415,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6c/Soul_Eater.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soul_Eater"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soul_Eater"
       },
       {
         "name": "Spider Web",
@@ -3432,7 +3432,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1d/Spider_Web.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spider_Web"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spider_Web"
       },
       {
         "name": "Sticker Freak",
@@ -3449,7 +3449,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/9e/Sticker_Freak.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sticker_Freak"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sticker_Freak"
       },
       {
         "name": "Sulis",
@@ -3474,7 +3474,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bf/Sulis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sulis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sulis"
       },
       {
         "name": "Super Chimry (Passion)",
@@ -3487,7 +3487,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0f/Super_Chimry_%28Passion%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Chimry_(Passion)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Chimry_(Passion)"
       },
       {
         "name": "Thetis",
@@ -3500,7 +3500,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a7/Thetis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thetis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thetis"
       },
       {
         "name": "Tisiphone",
@@ -3513,7 +3513,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b6/Tisiphone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tisiphone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tisiphone"
       },
       {
         "name": "Tomato Juice",
@@ -3526,7 +3526,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Tomato_Juice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tomato_Juice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tomato_Juice"
       },
       {
         "name": "Tomoe",
@@ -3543,7 +3543,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0a/Tomoe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tomoe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tomoe"
       },
       {
         "name": "Tomoe Gozen",
@@ -3556,7 +3556,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/87/Tomoe_Gozen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tomoe_Gozen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tomoe_Gozen"
       },
       {
         "name": "Uranus",
@@ -3573,7 +3573,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ec/Uranus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Uranus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Uranus"
       },
       {
         "name": "Vermilion Bird",
@@ -3586,7 +3586,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/82/Vermilion_Bird.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vermilion_Bird"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vermilion_Bird"
       },
       {
         "name": "Vesta",
@@ -3599,7 +3599,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/da/Vesta_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vesta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vesta"
       },
       {
         "name": "Volcanus",
@@ -3612,7 +3612,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ec/Volcanus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Volcanus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Volcanus"
       },
       {
         "name": "Warning",
@@ -3625,7 +3625,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cb/Warning.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Warning"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Warning"
       },
       {
         "name": "Whipper",
@@ -3642,7 +3642,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/fa/Whipper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Whipper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Whipper"
       },
       {
         "name": "White Dragon",
@@ -3655,7 +3655,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/91/White_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Dragon"
       },
       {
         "name": "Yosakoi",
@@ -3668,7 +3668,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/da/Yosakoi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yosakoi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yosakoi"
       },
       {
         "name": "Zenobia",
@@ -3685,7 +3685,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b2/Zenobia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zenobia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zenobia"
       },
       {
         "name": "Alexia",
@@ -3702,7 +3702,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b2/Alexia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alexia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alexia"
       },
       {
         "name": "Alien Hypnos",
@@ -3719,7 +3719,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/36/Alien_Hypnos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Hypnos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Hypnos"
       },
       {
         "name": "Almace",
@@ -3736,7 +3736,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e1/Almace.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Almace"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Almace"
       },
       {
         "name": "Amanojaku",
@@ -3753,7 +3753,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b3/Amanojaku.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amanojaku"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amanojaku"
       },
       {
         "name": "Amaymon",
@@ -3770,7 +3770,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/40/Amaymon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amaymon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amaymon"
       },
       {
         "name": "Ana",
@@ -3791,7 +3791,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/76/Ana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ana"
       },
       {
         "name": "Anat",
@@ -3808,7 +3808,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/37/Anat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anat"
       },
       {
         "name": "Angelic Page",
@@ -3821,7 +3821,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/88/Angelic_Page_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angelic_Page"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angelic_Page"
       },
       {
         "name": "Aoide",
@@ -3842,7 +3842,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4a/Aoide.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aoide"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aoide"
       },
       {
         "name": "Arpa",
@@ -3871,7 +3871,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/69/Arpa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arpa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arpa"
       },
       {
         "name": "Baton Twirler",
@@ -3888,7 +3888,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/92/Baton_Twirler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Baton_Twirler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Baton_Twirler"
       },
       {
         "name": "Belisama",
@@ -3905,7 +3905,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/90/Belisama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Belisama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Belisama"
       },
       {
         "name": "Bookworm",
@@ -3922,7 +3922,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/79/Bookworm.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bookworm"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bookworm"
       },
       {
         "name": "Bounty Knight",
@@ -3939,7 +3939,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/60/Bounty_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bounty_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bounty_Knight"
       },
       {
         "name": "Brook",
@@ -3956,7 +3956,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/55/Brook.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brook"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brook"
       },
       {
         "name": "Bumpkin",
@@ -3973,7 +3973,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b9/Bumpkin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bumpkin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bumpkin"
       },
       {
         "name": "Cacao Hunter",
@@ -3990,7 +3990,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c9/Cacao_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cacao_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cacao_Hunter"
       },
       {
         "name": "Cacao Knight",
@@ -4007,7 +4007,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/55/Cacao_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cacao_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cacao_Knight"
       },
       {
         "name": "Cake Lover",
@@ -4024,7 +4024,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f9/Cake_Lover.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cake_Lover"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cake_Lover"
       },
       {
         "name": "Candy Cannon",
@@ -4041,7 +4041,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/57/Candy_Cannon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Candy_Cannon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Candy_Cannon"
       },
       {
         "name": "Canele",
@@ -4058,7 +4058,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/77/Canele.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Canele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Canele"
       },
       {
         "name": "Captain Kate",
@@ -4075,7 +4075,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/96/Captain_Kate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Kate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Kate"
       },
       {
         "name": "Caspiel",
@@ -4092,7 +4092,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a5/Caspiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Caspiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Caspiel"
       },
       {
         "name": "Catcine",
@@ -4109,7 +4109,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/6e/Catcine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Catcine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Catcine"
       },
       {
         "name": "Celesta",
@@ -4126,7 +4126,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0a/Celesta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celesta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celesta"
       },
       {
         "name": "Celestia",
@@ -4147,7 +4147,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/83/Celestia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celestia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celestia"
       },
       {
         "name": "Celestial Oracle",
@@ -4164,7 +4164,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f1/Celestial_Oracle_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celestial_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celestial_Oracle"
       },
       {
         "name": "Chernobog",
@@ -4181,7 +4181,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5c/Chernobog.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chernobog"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chernobog"
       },
       {
         "name": "Circo",
@@ -4206,7 +4206,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/eb/Circo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Circo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Circo"
       },
       {
         "name": "Circo New Year",
@@ -4223,7 +4223,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f1/Circo_New_Year.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Circo_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Circo_New_Year"
       },
       {
         "name": "Cosplay Vamp",
@@ -4240,7 +4240,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/eb/Cosplay_Vamp_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cosplay_Vamp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cosplay_Vamp"
       },
       {
         "name": "Crescendo",
@@ -4257,7 +4257,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b1/Crescendo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crescendo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crescendo"
       },
       {
         "name": "Daedalus",
@@ -4274,7 +4274,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/39/Daedalus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Daedalus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Daedalus"
       },
       {
         "name": "Dame Almace",
@@ -4291,7 +4291,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3e/Dame_Almace_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dame_Almace"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dame_Almace"
       },
       {
         "name": "Dame Joyeuse",
@@ -4308,7 +4308,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/69/Dame_Joyeuse_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dame_Joyeuse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dame_Joyeuse"
       },
       {
         "name": "Dancing Sally",
@@ -4325,7 +4325,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dc/Dancing_Sally.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dancing_Sally"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dancing_Sally"
       },
       {
         "name": "Dark Eyes",
@@ -4338,7 +4338,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4b/Dark_Eyes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Eyes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Eyes"
       },
       {
         "name": "Dark Eyes Unveiled",
@@ -4355,7 +4355,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/80/Dark_Eyes_Unveiled_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Eyes_Unveiled"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Eyes_Unveiled"
       },
       {
         "name": "Decima",
@@ -4372,7 +4372,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7b/Decima.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Decima"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Decima"
       },
       {
         "name": "Demiurge",
@@ -4393,7 +4393,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3d/Demiurge.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demiurge"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demiurge"
       },
       {
         "name": "Diabolic Six",
@@ -4410,7 +4410,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/75/Diabolic_Six.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diabolic_Six"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diabolic_Six"
       },
       {
         "name": "Dimension Fiancee",
@@ -4427,7 +4427,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1b/Dimension_Fiancee_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dimension_Fiancee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dimension_Fiancee"
       },
       {
         "name": "Dimension Hacker",
@@ -4444,7 +4444,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cd/Dimension_Hacker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dimension_Hacker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dimension_Hacker"
       },
       {
         "name": "Diva Aki",
@@ -4461,7 +4461,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1b/Diva_Aki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diva_Aki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diva_Aki"
       },
       {
         "name": "Diva Mika",
@@ -4474,7 +4474,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bd/Diva_Mika_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diva_Mika"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diva_Mika"
       },
       {
         "name": "Ellery",
@@ -4491,7 +4491,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bd/Ellery.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ellery"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ellery"
       },
       {
         "name": "Ema",
@@ -4512,7 +4512,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/30/Ema.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ema"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ema"
       },
       {
         "name": "Empress Cleopatra",
@@ -4533,7 +4533,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/35/Empress_Cleopatra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress_Cleopatra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress_Cleopatra"
       },
       {
         "name": "Ester",
@@ -4550,7 +4550,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/22/Ester.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ester"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ester"
       },
       {
         "name": "Eternal Fortuna",
@@ -4567,7 +4567,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0b/Eternal_Fortuna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eternal_Fortuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eternal_Fortuna"
       },
       {
         "name": "Fairina",
@@ -4588,7 +4588,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/84/Fairina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fairina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fairina"
       },
       {
         "name": "Faust",
@@ -4605,7 +4605,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d0/Faust.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Faust"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Faust"
       },
       {
         "name": "Fiery Lu Bu The Red",
@@ -4618,7 +4618,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a2/Fiery_Lu_Bu_The_Red_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fiery_Lu_Bu_The_Red"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fiery_Lu_Bu_The_Red"
       },
       {
         "name": "Flashdance Lantz",
@@ -4635,7 +4635,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/59/Flashdance_Lantz_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flashdance_Lantz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flashdance_Lantz"
       },
       {
         "name": "Freyja",
@@ -4652,7 +4652,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/cd/Freyja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Freyja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Freyja"
       },
       {
         "name": "Furfur",
@@ -4669,7 +4669,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/30/Furfur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furfur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furfur"
       },
       {
         "name": "Furries",
@@ -4686,7 +4686,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/53/Furries.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furries"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furries"
       },
       {
         "name": "Gianna",
@@ -4703,7 +4703,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8c/Gianna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gianna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gianna"
       },
       {
         "name": "Gilgamesh",
@@ -4716,7 +4716,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d7/Gilgamesh.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gilgamesh"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gilgamesh"
       },
       {
         "name": "Goetia",
@@ -4733,7 +4733,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e6/Goetia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Goetia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Goetia"
       },
       {
         "name": "Goth Oracle",
@@ -4754,7 +4754,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e1/Goth_Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Goth_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Goth_Oracle"
       },
       {
         "name": "Gozaru",
@@ -4771,7 +4771,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/36/Gozaru.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gozaru"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gozaru"
       },
       {
         "name": "Halloween Hades",
@@ -4788,7 +4788,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2d/Halloween_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Halloween_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Halloween_Hades"
       },
       {
         "name": "Hebe",
@@ -4805,7 +4805,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/90/Hebe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hebe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hebe"
       },
       {
         "name": "Heroic Gilgamesh",
@@ -4822,7 +4822,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/42/Heroic_Gilgamesh_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Heroic_Gilgamesh"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Heroic_Gilgamesh"
       },
       {
         "name": "Honey Bee",
@@ -4839,7 +4839,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c3/Honey_Bee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Honey_Bee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Honey_Bee"
       },
       {
         "name": "Hot Pot Master",
@@ -4856,7 +4856,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/22/Hot_Pot_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hot_Pot_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hot_Pot_Master"
       },
       {
         "name": "Hotline",
@@ -4873,7 +4873,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7c/Hotline.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hotline"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hotline"
       },
       {
         "name": "Hyper Chimry (Passion)",
@@ -4886,7 +4886,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b0/Hyper_Chimry_%28Passion%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Chimry_(Passion)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Chimry_(Passion)"
       },
       {
         "name": "Inanna",
@@ -4903,7 +4903,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2a/Inanna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Inanna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Inanna"
       },
       {
         "name": "Ishikore-Dome",
@@ -4920,7 +4920,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7f/Ishikore-Dome.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ishikore-Dome"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ishikore-Dome"
       },
       {
         "name": "Ixtab",
@@ -4937,7 +4937,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c6/Ixtab.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ixtab"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ixtab"
       },
       {
         "name": "Jack the Ripper",
@@ -4954,7 +4954,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/91/Jack_the_Ripper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jack_the_Ripper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jack_the_Ripper"
       },
       {
         "name": "Jewel Girl",
@@ -4971,7 +4971,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/77/Jewel_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jewel_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jewel_Girl"
       },
       {
         "name": "Joyeuse",
@@ -4988,7 +4988,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d5/Joyeuse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Joyeuse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Joyeuse"
       },
       {
         "name": "Julia",
@@ -5005,7 +5005,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6e/Julia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Julia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Julia"
       },
       {
         "name": "Jupiter",
@@ -5022,7 +5022,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/68/Jupiter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jupiter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jupiter"
       },
       {
         "name": "Kamuy Fuchi",
@@ -5039,7 +5039,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/59/Kamuy_Fuchi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kamuy_Fuchi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kamuy_Fuchi"
       },
       {
         "name": "Kelvin",
@@ -5056,7 +5056,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/22/Kelvin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kelvin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kelvin"
       },
       {
         "name": "Kid Gloves",
@@ -5073,7 +5073,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bb/Kid_Gloves.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kid_Gloves"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kid_Gloves"
       },
       {
         "name": "Kinkan",
@@ -5090,7 +5090,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/76/Kinkan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kinkan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kinkan"
       },
       {
         "name": "Klein",
@@ -5107,7 +5107,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1e/Klein.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Klein"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Klein"
       },
       {
         "name": "Kruenelle",
@@ -5124,7 +5124,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cd/Kruenelle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kruenelle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kruenelle"
       },
       {
         "name": "Lady Alexia",
@@ -5141,7 +5141,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5d/Lady_Alexia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lady_Alexia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lady_Alexia"
       },
       {
         "name": "Lancelot",
@@ -5158,7 +5158,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/cd/Lancelot.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lancelot"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lancelot"
       },
       {
         "name": "Lantz",
@@ -5175,7 +5175,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e9/Lantz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lantz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lantz"
       },
       {
         "name": "Lapis",
@@ -5192,7 +5192,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5d/Lapis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lapis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lapis"
       },
       {
         "name": "Lapis Lazuli",
@@ -5209,7 +5209,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9f/Lapis_Lazuli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lapis_Lazuli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lapis_Lazuli"
       },
       {
         "name": "Laudable Klein",
@@ -5226,7 +5226,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/13/Laudable_Klein_G.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Laudable_Klein"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Laudable_Klein"
       },
       {
         "name": "Launcher",
@@ -5243,7 +5243,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/85/Launcher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Launcher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Launcher"
       },
       {
         "name": "Letta",
@@ -5272,7 +5272,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/fa/Letta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Letta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Letta"
       },
       {
         "name": "Little Grey",
@@ -5289,7 +5289,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e8/Little_Grey.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Grey"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Grey"
       },
       {
         "name": "Loki",
@@ -5306,7 +5306,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fe/Loki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Loki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Loki"
       },
       {
         "name": "Louise",
@@ -5323,7 +5323,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1f/Louise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Louise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Louise"
       },
       {
         "name": "Love Smash",
@@ -5340,7 +5340,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c6/Love_Smash.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Love_Smash"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Love_Smash"
       },
       {
         "name": "Lovely Shion",
@@ -5357,7 +5357,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/70/Lovely_Shion_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lovely_Shion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lovely_Shion"
       },
       {
         "name": "Lover Demon",
@@ -5374,7 +5374,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/16/Lover_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lover_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lover_Demon"
       },
       {
         "name": "Lu Bu The Red",
@@ -5387,7 +5387,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b0/Lu_Bu_The_Red_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lu_Bu_The_Red"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lu_Bu_The_Red"
       },
       {
         "name": "Lu Bu The Swift",
@@ -5404,7 +5404,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/40/Lu_Bu_The_Swift.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lu_Bu_The_Swift"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lu_Bu_The_Swift"
       },
       {
         "name": "Lune",
@@ -5421,7 +5421,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/97/Lune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lune"
       },
       {
         "name": "Madolche",
@@ -5438,7 +5438,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/10/Madolche.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Madolche"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Madolche"
       },
       {
         "name": "Magma",
@@ -5455,7 +5455,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Magma.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Magma"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Magma"
       },
       {
         "name": "Matchmaker",
@@ -5472,7 +5472,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/09/Matchmaker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Matchmaker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Matchmaker"
       },
       {
         "name": "Megaera",
@@ -5489,7 +5489,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f9/Megaera.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Megaera"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Megaera"
       },
       {
         "name": "Mete",
@@ -5506,7 +5506,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/91/Mete.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mete"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mete"
       },
       {
         "name": "Mildred",
@@ -5523,7 +5523,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/43/Mildred.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mildred"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mildred"
       },
       {
         "name": "Mineria",
@@ -5540,7 +5540,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c7/Mineria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mineria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mineria"
       },
       {
         "name": "Minister Vielle",
@@ -5557,7 +5557,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d6/Minister_Vielle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minister_Vielle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minister_Vielle"
       },
       {
         "name": "Moira",
@@ -5574,7 +5574,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b5/Moira.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Moira"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Moira"
       },
       {
         "name": "Monkey",
@@ -5591,7 +5591,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/27/Monkey.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Monkey"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Monkey"
       },
       {
         "name": "Mummu",
@@ -5608,7 +5608,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fb/Mummu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mummu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mummu"
       },
       {
         "name": "Newbie Witch",
@@ -5625,7 +5625,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/44/Newbie_Witch.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Newbie_Witch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Newbie_Witch"
       },
       {
         "name": "Nina",
@@ -5642,7 +5642,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/97/Nina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nina"
       },
       {
         "name": "Nuisance",
@@ -5659,7 +5659,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/44/Nuisance.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nuisance"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nuisance"
       },
       {
         "name": "Odin",
@@ -5676,7 +5676,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/58/Odin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Odin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Odin"
       },
       {
         "name": "Ometeotl",
@@ -5693,7 +5693,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/30/Ometeotl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ometeotl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ometeotl"
       },
       {
         "name": "Oracle Chair",
@@ -5714,7 +5714,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f8/Oracle_Chair.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oracle_Chair"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oracle_Chair"
       },
       {
         "name": "Oracle In Love",
@@ -5735,7 +5735,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/41/Oracle_In_Love.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oracle_In_Love"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oracle_In_Love"
       },
       {
         "name": "Oriens",
@@ -5752,7 +5752,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b7/Oriens.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oriens"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oriens"
       },
       {
         "name": "Overseer Vielle",
@@ -5765,7 +5765,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Overseer_Vielle_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Overseer_Vielle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Overseer_Vielle"
       },
       {
         "name": "Page",
@@ -5782,7 +5782,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/95/Page.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Page"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Page"
       },
       {
         "name": "Pala",
@@ -5799,7 +5799,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a3/Pala.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pala"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pala"
       },
       {
         "name": "Pasiphae",
@@ -5816,7 +5816,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4a/Pasiphae.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pasiphae"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pasiphae"
       },
       {
         "name": "Peacock",
@@ -5833,7 +5833,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/61/Peacock.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Peacock"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Peacock"
       },
       {
         "name": "Phantom Ninja",
@@ -5850,7 +5850,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d8/Phantom_Ninja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Phantom_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Phantom_Ninja"
       },
       {
         "name": "Phoenix",
@@ -5867,7 +5867,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c1/Phoenix.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Phoenix"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Phoenix"
       },
       {
         "name": "Pixie Servant",
@@ -5884,7 +5884,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/ca/Pixie_Servant.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pixie_Servant"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pixie_Servant"
       },
       {
         "name": "Platinum Fairy",
@@ -5901,7 +5901,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/81/Platinum_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Platinum_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Platinum_Fairy"
       },
       {
         "name": "Please",
@@ -5922,7 +5922,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Please.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Please"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Please"
       },
       {
         "name": "Praline",
@@ -5939,7 +5939,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/70/Praline.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Praline"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Praline"
       },
       {
         "name": "Precious Lazuli",
@@ -5956,7 +5956,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/79/Precious_Lazuli_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Precious_Lazuli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Precious_Lazuli"
       },
       {
         "name": "Precious Quoise",
@@ -5973,7 +5973,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/75/Precious_Quoise_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Precious_Quoise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Precious_Quoise"
       },
       {
         "name": "President Nina",
@@ -5986,7 +5986,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/eb/President_Nina_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/President_Nina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/President_Nina"
       },
       {
         "name": "Pretty Kisaragi",
@@ -6003,7 +6003,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/72/Pretty_Kisaragi_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pretty_Kisaragi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pretty_Kisaragi"
       },
       {
         "name": "Prometheus",
@@ -6020,7 +6020,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/63/Prometheus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Prometheus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Prometheus"
       },
       {
         "name": "Pure Oracle",
@@ -6037,7 +6037,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3f/Pure_Oracle_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pure_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pure_Oracle"
       },
       {
         "name": "Ran",
@@ -6054,7 +6054,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/64/Ran.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ran"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ran"
       },
       {
         "name": "Reaper",
@@ -6071,7 +6071,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6a/Reaper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Reaper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Reaper"
       },
       {
         "name": "Red Sally",
@@ -6088,7 +6088,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/05/Red_Sally_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Sally"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Sally"
       },
       {
         "name": "Riley",
@@ -6105,7 +6105,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/58/Riley.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Riley"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Riley"
       },
       {
         "name": "Rogue",
@@ -6122,7 +6122,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/59/Rogue.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rogue"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rogue"
       },
       {
         "name": "Rogue The Savior",
@@ -6135,7 +6135,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/82/Rogue_The_Savior_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rogue_The_Savior"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rogue_The_Savior"
       },
       {
         "name": "Rogue The Vengeful",
@@ -6148,7 +6148,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/51/Rogue_The_Vengeful_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rogue_The_Vengeful"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rogue_The_Vengeful"
       },
       {
         "name": "Rushika",
@@ -6165,7 +6165,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fd/Rushika.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rushika"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rushika"
       },
       {
         "name": "Sacred Seika",
@@ -6182,7 +6182,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/da/Sacred_Seika_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacred_Seika"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacred_Seika"
       },
       {
         "name": "Saga",
@@ -6199,7 +6199,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a4/Saga.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saga"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saga"
       },
       {
         "name": "Santa's Helper",
@@ -6216,7 +6216,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f6/Santa%27s_Helper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santa%27s_Helper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santa%27s_Helper"
       },
       {
         "name": "Santa Oracle",
@@ -6233,7 +6233,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fe/Santa_Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santa_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santa_Oracle"
       },
       {
         "name": "Santiclaus",
@@ -6254,7 +6254,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/46/Santiclaus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santiclaus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santiclaus"
       },
       {
         "name": "Sarugami",
@@ -6271,7 +6271,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c4/Sarugami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sarugami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sarugami"
       },
       {
         "name": "Saucemeister",
@@ -6288,7 +6288,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/87/Saucemeister.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saucemeister"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saucemeister"
       },
       {
         "name": "Scheherazade",
@@ -6305,7 +6305,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f8/Scheherazade.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scheherazade"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scheherazade"
       },
       {
         "name": "Seere",
@@ -6322,7 +6322,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/46/Seere.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Seere"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Seere"
       },
       {
         "name": "Seika",
@@ -6339,7 +6339,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/cc/Seika.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Seika"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Seika"
       },
       {
         "name": "Sleipnir",
@@ -6356,7 +6356,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/45/Sleipnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sleipnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sleipnir"
       },
       {
         "name": "Snape",
@@ -6373,7 +6373,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fe/Snape.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snape"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snape"
       },
       {
         "name": "Stocking Master",
@@ -6390,7 +6390,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7e/Stocking_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stocking_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stocking_Master"
       },
       {
         "name": "Stone Elf",
@@ -6407,7 +6407,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/62/Stone_Elf.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stone_Elf"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stone_Elf"
       },
       {
         "name": "Stylish Kisaragi",
@@ -6424,7 +6424,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4c/Stylish_Kisaragi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stylish_Kisaragi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stylish_Kisaragi"
       },
       {
         "name": "Summer Alchemist",
@@ -6441,7 +6441,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e6/Summer_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Summer_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Summer_Alchemist"
       },
       {
         "name": "Sunset Alchemist",
@@ -6458,7 +6458,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/69/Sunset_Alchemist_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sunset_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sunset_Alchemist"
       },
       {
         "name": "Superstar Mika",
@@ -6475,7 +6475,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/dc/Superstar_Mika.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Superstar_Mika"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Superstar_Mika"
       },
       {
         "name": "Tatara",
@@ -6492,7 +6492,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/69/Tatara.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tatara"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tatara"
       },
       {
         "name": "Teen Shion",
@@ -6509,7 +6509,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e4/Teen_Shion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teen_Shion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teen_Shion"
       },
       {
         "name": "Tefnut",
@@ -6526,7 +6526,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8b/Tefnut.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tefnut"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tefnut"
       },
       {
         "name": "The Grand Pure One",
@@ -6543,7 +6543,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7f/The_Grand_Pure_One.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/The_Grand_Pure_One"
+        "link": "http://valkyriecrusade.fandom.com/wiki/The_Grand_Pure_One"
       },
       {
         "name": "The Stupendous Robin",
@@ -6560,7 +6560,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/93/The_Stupendous_Robin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/The_Stupendous_Robin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/The_Stupendous_Robin"
       },
       {
         "name": "Turquoise",
@@ -6577,7 +6577,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/aa/Turquoise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Turquoise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Turquoise"
       },
       {
         "name": "Toy Box",
@@ -6594,7 +6594,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b1/Toy_Box.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toy_Box"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toy_Box"
       },
       {
         "name": "Trap Master",
@@ -6611,7 +6611,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2a/Trap_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Trap_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Trap_Master"
       },
       {
         "name": "Tristesse",
@@ -6628,7 +6628,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0a/Tristesse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tristesse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tristesse"
       },
       {
         "name": "Tyr",
@@ -6645,7 +6645,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/76/Tyr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tyr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tyr"
       },
       {
         "name": "Umbrella",
@@ -6662,7 +6662,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/06/Umbrella.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Umbrella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Umbrella"
       },
       {
         "name": "Unhappy Valentine",
@@ -6679,7 +6679,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4c/Unhappy_Valentine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Unhappy_Valentine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Unhappy_Valentine"
       },
       {
         "name": "Valentine",
@@ -6696,7 +6696,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4a/Valentine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valentine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valentine"
       },
       {
         "name": "Vamp",
@@ -6713,7 +6713,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/59/Vamp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vamp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vamp"
       },
       {
         "name": "Vampire Victoria",
@@ -6726,7 +6726,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/af/Vampire_Victoria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vampire_Victoria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vampire_Victoria"
       },
       {
         "name": "Vermillion Victoria",
@@ -6743,7 +6743,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bf/Vermillion_Victoria_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vermillion_Victoria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vermillion_Victoria"
       },
       {
         "name": "Vigilent",
@@ -6760,7 +6760,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/be/Vigilent.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vigilent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vigilent"
       },
       {
         "name": "Wa Ran",
@@ -6777,7 +6777,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/88/Wa_Ran_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wa_Ran"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wa_Ran"
       },
       {
         "name": "Wadatsumi",
@@ -6794,7 +6794,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/94/Wadatsumi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wadatsumi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wadatsumi"
       },
       {
         "name": "Waltraute",
@@ -6815,7 +6815,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/89/Waltraute.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Waltraute"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Waltraute"
       },
       {
         "name": "Warrior Pup",
@@ -6832,7 +6832,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ab/Warrior_Pup.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Warrior_Pup"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Warrior_Pup"
       },
       {
         "name": "Wicca Mildred",
@@ -6845,7 +6845,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2f/Wicca_Mildred_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wicca_Mildred"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wicca_Mildred"
       },
       {
         "name": "William",
@@ -6862,7 +6862,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0b/William.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/William"
+        "link": "http://valkyriecrusade.fandom.com/wiki/William"
       },
       {
         "name": "Winged Vigilent",
@@ -6879,7 +6879,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f5/Winged_Vigilent_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Winged_Vigilent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Winged_Vigilent"
       },
       {
         "name": "Bridal Kisaragi",
@@ -6904,7 +6904,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b8/Bridal_Kisaragi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bridal_Kisaragi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bridal_Kisaragi"
       },
       {
         "name": "Everi",
@@ -6929,7 +6929,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c7/Everi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Everi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Everi"
       },
       {
         "name": "God Scheherazade",
@@ -6954,7 +6954,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5b/God_Scheherazade.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/God_Scheherazade"
+        "link": "http://valkyriecrusade.fandom.com/wiki/God_Scheherazade"
       },
       {
         "name": "Queen Shion",
@@ -6979,7 +6979,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6b/Queen_Shion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Shion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Shion"
       },
       {
         "name": "Roselia",
@@ -7004,7 +7004,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f9/Roselia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roselia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roselia"
       },
       {
         "name": "Simon Says",
@@ -7029,7 +7029,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ae/Simon_Says.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Simon_Says"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Simon_Says"
       },
       {
         "name": "Tamiel",
@@ -7062,7 +7062,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/88/Tamiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tamiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tamiel"
       },
       {
         "name": "True Victoria",
@@ -7087,7 +7087,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/91/True_Victoria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Victoria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Victoria"
       },
       {
         "name": "Vernal",
@@ -7112,7 +7112,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/56/Vernal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vernal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vernal"
       },
       {
         "name": "Wise Oracle",
@@ -7145,7 +7145,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8a/Wise_Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wise_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wise_Oracle"
       },
       {
         "name": "Agent",
@@ -7158,7 +7158,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f3/Agent.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Agent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Agent"
       },
       {
         "name": "Airavata",
@@ -7171,7 +7171,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/70/Airavata.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Airavata"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Airavata"
       },
       {
         "name": "Aither",
@@ -7184,7 +7184,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8a/Aither.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aither"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aither"
       },
       {
         "name": "Alraune",
@@ -7197,7 +7197,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/83/Alraune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alraune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alraune"
       },
       {
         "name": "Android",
@@ -7210,7 +7210,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/ce/Android.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Android"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Android"
       },
       {
         "name": "Anello",
@@ -7223,7 +7223,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2f/Anello.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anello"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anello"
       },
       {
         "name": "Aqua Knight",
@@ -7236,7 +7236,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a9/Aqua_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aqua_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aqua_Knight"
       },
       {
         "name": "Arnage",
@@ -7249,7 +7249,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/be/Arnage.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arnage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arnage"
       },
       {
         "name": "Assistant Loid",
@@ -7262,7 +7262,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4b/Assistant_Loid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Assistant_Loid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Assistant_Loid"
       },
       {
         "name": "Banshee",
@@ -7275,7 +7275,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d3/Banshee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Banshee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Banshee"
       },
       {
         "name": "Bartender",
@@ -7288,7 +7288,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9c/Bartender.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bartender"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bartender"
       },
       {
         "name": "Bat Babe",
@@ -7301,7 +7301,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bc/Bat_Babe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bat_Babe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bat_Babe"
       },
       {
         "name": "Bellona",
@@ -7314,7 +7314,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1f/Bellona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bellona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bellona"
       },
       {
         "name": "Bishamonten",
@@ -7327,7 +7327,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/23/Bishamonten.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bishamonten"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bishamonten"
       },
       {
         "name": "Brave",
@@ -7340,7 +7340,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5b/Brave.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brave"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brave"
       },
       {
         "name": "Bubbles",
@@ -7353,7 +7353,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0c/Bubbles.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bubbles"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bubbles"
       },
       {
         "name": "Camerawoman",
@@ -7366,7 +7366,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/30/Camerawoman.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Camerawoman"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Camerawoman"
       },
       {
         "name": "Carmilla",
@@ -7379,7 +7379,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1d/Carmilla.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Carmilla"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Carmilla"
       },
       {
         "name": "Cassandra",
@@ -7392,7 +7392,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9d/Cassandra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cassandra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cassandra"
       },
       {
         "name": "Cat Punch",
@@ -7405,7 +7405,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3f/Cat_Punch.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cat_Punch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cat_Punch"
       },
       {
         "name": "Chocomint",
@@ -7418,7 +7418,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/70/Chocomint.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocomint"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocomint"
       },
       {
         "name": "Clutho",
@@ -7431,7 +7431,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/24/Clutho.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Clutho"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Clutho"
       },
       {
         "name": "Colonel",
@@ -7444,7 +7444,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/02/Colonel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Colonel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Colonel"
       },
       {
         "name": "Conch Angel",
@@ -7457,7 +7457,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f5/Conch_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Conch_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Conch_Angel"
       },
       {
         "name": "Demeter",
@@ -7470,7 +7470,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/03/Demeter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demeter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demeter"
       },
       {
         "name": "Dental Fairy",
@@ -7483,7 +7483,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Dental_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dental_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dental_Fairy"
       },
       {
         "name": "Desperado",
@@ -7496,7 +7496,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/57/Desperado.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Desperado"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Desperado"
       },
       {
         "name": "Detective",
@@ -7509,7 +7509,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7f/Detective.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Detective"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Detective"
       },
       {
         "name": "Diva",
@@ -7522,7 +7522,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/49/Diva.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diva"
       },
       {
         "name": "Doctor",
@@ -7535,7 +7535,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6c/Doctor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doctor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doctor"
       },
       {
         "name": "Dogsled Girl",
@@ -7548,7 +7548,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0b/Dogsled_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dogsled_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dogsled_Girl"
       },
       {
         "name": "Element Collector",
@@ -7561,7 +7561,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/49/Element_Collector.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Element_Collector"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Element_Collector"
       },
       {
         "name": "Emilia",
@@ -7574,7 +7574,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e0/Emilia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Emilia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Emilia"
       },
       {
         "name": "Ent",
@@ -7587,7 +7587,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/05/Ent.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ent"
       },
       {
         "name": "Eunomia",
@@ -7600,7 +7600,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/36/Eunomia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eunomia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eunomia"
       },
       {
         "name": "Europa",
@@ -7613,7 +7613,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/63/Europa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Europa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Europa"
       },
       {
         "name": "Firewings",
@@ -7626,7 +7626,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5d/Firewings.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Firewings"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Firewings"
       },
       {
         "name": "Flo",
@@ -7639,7 +7639,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b5/Flo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flo"
       },
       {
         "name": "Fox Spirit",
@@ -7652,7 +7652,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5d/Fox_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fox_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fox_Spirit"
       },
       {
         "name": "Gae Bulg",
@@ -7665,7 +7665,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Gae_Bulg.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gae_Bulg"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gae_Bulg"
       },
       {
         "name": "Ghost Ship",
@@ -7678,7 +7678,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b1/Ghost_Ship.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghost_Ship"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghost_Ship"
       },
       {
         "name": "Glutton",
@@ -7691,7 +7691,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/39/Glutton.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Glutton"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Glutton"
       },
       {
         "name": "Gossip",
@@ -7704,7 +7704,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a4/Gossip.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gossip"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gossip"
       },
       {
         "name": "Hacker",
@@ -7717,7 +7717,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e2/Hacker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hacker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hacker"
       },
       {
         "name": "Halloweena",
@@ -7730,7 +7730,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7c/Halloweena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Halloweena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Halloweena"
       },
       {
         "name": "Hamelin",
@@ -7743,7 +7743,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/88/Hamelin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hamelin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hamelin"
       },
       {
         "name": "Hermit",
@@ -7756,7 +7756,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1e/Hermit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hermit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hermit"
       },
       {
         "name": "Hopper",
@@ -7769,7 +7769,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/81/Hopper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hopper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hopper"
       },
       {
         "name": "Hustler",
@@ -7782,7 +7782,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3f/Hustler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hustler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hustler"
       },
       {
         "name": "Hydra",
@@ -7795,7 +7795,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9d/Hydra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hydra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hydra"
       },
       {
         "name": "Idler",
@@ -7808,7 +7808,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/be/Idler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Idler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Idler"
       },
       {
         "name": "Illuminatia",
@@ -7821,7 +7821,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e3/Illuminatia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Illuminatia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Illuminatia"
       },
       {
         "name": "Iron Maiden",
@@ -7834,7 +7834,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c0/Iron_Maiden.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Iron_Maiden"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Iron_Maiden"
       },
       {
         "name": "Jacoba",
@@ -7847,7 +7847,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/34/Jacoba.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jacoba"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jacoba"
       },
       {
         "name": "Jester",
@@ -7860,7 +7860,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e0/Jester.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jester"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jester"
       },
       {
         "name": "Juturna",
@@ -7873,7 +7873,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ef/Juturna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Juturna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Juturna"
       },
       {
         "name": "Kama",
@@ -7886,7 +7886,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f0/Kama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kama"
       },
       {
         "name": "Kamaitachi",
@@ -7899,7 +7899,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4c/Kamaitachi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kamaitachi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kamaitachi"
       },
       {
         "name": "Kappa",
@@ -7912,7 +7912,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/81/Kappa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kappa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kappa"
       },
       {
         "name": "Kawahime",
@@ -7925,7 +7925,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/45/Kawahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kawahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kawahime"
       },
       {
         "name": "Kelpie",
@@ -7938,7 +7938,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/10/Kelpie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kelpie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kelpie"
       },
       {
         "name": "Kushinadahime",
@@ -7951,7 +7951,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/60/Kushinadahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kushinadahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kushinadahime"
       },
       {
         "name": "Lachesis",
@@ -7964,7 +7964,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/29/Lachesis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lachesis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lachesis"
       },
       {
         "name": "Licensed Diver",
@@ -7977,7 +7977,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/86/Licensed_Diver.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Licensed_Diver"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Licensed_Diver"
       },
       {
         "name": "Lightning",
@@ -7990,7 +7990,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/86/Lightning.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lightning"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lightning"
       },
       {
         "name": "Lil' Wings",
@@ -8003,7 +8003,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/41/Lil%27_Wings.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lil%27_Wings"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lil%27_Wings"
       },
       {
         "name": "Malady",
@@ -8016,7 +8016,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9b/Malady.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Malady"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Malady"
       },
       {
         "name": "Mary",
@@ -8029,7 +8029,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Mary.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mary"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mary"
       },
       {
         "name": "Medb",
@@ -8042,7 +8042,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/38/Medb_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medb"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medb"
       },
       {
         "name": "Melissa",
@@ -8055,7 +8055,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/74/Melissa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melissa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melissa"
       },
       {
         "name": "Mercury",
@@ -8068,7 +8068,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/41/Mercury.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mercury"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mercury"
       },
       {
         "name": "Mermaid Princess",
@@ -8081,7 +8081,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/32/Mermaid_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mermaid_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mermaid_Princess"
       },
       {
         "name": "Minerva",
@@ -8094,7 +8094,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e2/Minerva.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minerva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minerva"
       },
       {
         "name": "Mneme",
@@ -8107,7 +8107,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/00/Mneme.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mneme"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mneme"
       },
       {
         "name": "Momotaro",
@@ -8120,7 +8120,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/cf/Momotaro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Momotaro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Momotaro"
       },
       {
         "name": "Morrigan",
@@ -8133,7 +8133,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/39/Morrigan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morrigan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morrigan"
       },
       {
         "name": "Murder",
@@ -8146,7 +8146,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/91/Murder.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Murder"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Murder"
       },
       {
         "name": "Musician",
@@ -8159,7 +8159,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/96/Musician.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Musician"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Musician"
       },
       {
         "name": "Musketeer",
@@ -8172,7 +8172,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/89/Musketeer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Musketeer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Musketeer"
       },
       {
         "name": "Nereid",
@@ -8185,7 +8185,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/30/Nereid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nereid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nereid"
       },
       {
         "name": "Oiran",
@@ -8198,7 +8198,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d2/Oiran.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oiran"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oiran"
       },
       {
         "name": "Paper Master",
@@ -8211,7 +8211,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/51/Paper_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paper_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paper_Master"
       },
       {
         "name": "Pomona",
@@ -8224,7 +8224,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c9/Pomona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pomona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pomona"
       },
       {
         "name": "Primed Hades",
@@ -8237,7 +8237,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b6/Primed_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Primed_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Primed_Hades"
       },
       {
         "name": "Pylon",
@@ -8250,7 +8250,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/11/Pylon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pylon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pylon"
       },
       {
         "name": "Queen Mother",
@@ -8263,7 +8263,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cd/Queen_Mother.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Mother"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Mother"
       },
       {
         "name": "Queen of Ice",
@@ -8276,7 +8276,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c5/Queen_of_Ice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_of_Ice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_of_Ice"
       },
       {
         "name": "Rhea",
@@ -8289,7 +8289,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/37/Rhea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rhea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rhea"
       },
       {
         "name": "Rocket Punch",
@@ -8302,7 +8302,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6b/Rocket_Punch.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rocket_Punch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rocket_Punch"
       },
       {
         "name": "Rune Knight",
@@ -8315,7 +8315,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7a/Rune_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rune_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rune_Knight"
       },
       {
         "name": "Rusalka",
@@ -8328,7 +8328,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/26/Rusalka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rusalka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rusalka"
       },
       {
         "name": "Sage",
@@ -8341,7 +8341,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f8/Sage.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sage"
       },
       {
         "name": "Sagittarius",
@@ -8354,7 +8354,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fa/Sagittarius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sagittarius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sagittarius"
       },
       {
         "name": "Sailor",
@@ -8367,7 +8367,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/ce/Sailor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sailor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sailor"
       },
       {
         "name": "Samurai",
@@ -8380,7 +8380,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/09/Samurai.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Samurai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Samurai"
       },
       {
         "name": "Sargasso",
@@ -8393,7 +8393,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b4/Sargasso.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sargasso"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sargasso"
       },
       {
         "name": "Scientist",
@@ -8406,7 +8406,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c3/Scientist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scientist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scientist"
       },
       {
         "name": "Sedna",
@@ -8419,7 +8419,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/48/Sedna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sedna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sedna"
       },
       {
         "name": "Selkie",
@@ -8432,7 +8432,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/90/Selkie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Selkie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Selkie"
       },
       {
         "name": "Shakespeare",
@@ -8445,7 +8445,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d8/Shakespeare.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shakespeare"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shakespeare"
       },
       {
         "name": "Shaman",
@@ -8458,7 +8458,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/56/Shaman.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shaman"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shaman"
       },
       {
         "name": "Shen",
@@ -8471,7 +8471,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0c/Shen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shen"
       },
       {
         "name": "Shikigami",
@@ -8484,7 +8484,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bd/Shikigami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shikigami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shikigami"
       },
       {
         "name": "Silver Demon",
@@ -8497,7 +8497,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1a/Silver_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Silver_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Silver_Demon"
       },
       {
         "name": "Sirius",
@@ -8510,7 +8510,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/18/Sirius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sirius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sirius"
       },
       {
         "name": "Ski Patroller",
@@ -8523,7 +8523,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/27/Ski_Patroller.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ski_Patroller"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ski_Patroller"
       },
       {
         "name": "Skuld",
@@ -8536,7 +8536,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Skuld.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skuld"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skuld"
       },
       {
         "name": "Sleepy Bear",
@@ -8549,7 +8549,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/28/Sleepy_Bear.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sleepy_Bear"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sleepy_Bear"
       },
       {
         "name": "Snow Mage",
@@ -8562,7 +8562,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c6/Snow_Mage.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snow_Mage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snow_Mage"
       },
       {
         "name": "Soldier",
@@ -8575,7 +8575,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7b/Soldier.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soldier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soldier"
       },
       {
         "name": "Sommelier",
@@ -8588,7 +8588,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/07/Sommelier.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sommelier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sommelier"
       },
       {
         "name": "Sorceress",
@@ -8601,7 +8601,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/96/Sorceress.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sorceress"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sorceress"
       },
       {
         "name": "Spacegirl",
@@ -8614,7 +8614,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/27/Spacegirl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spacegirl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spacegirl"
       },
       {
         "name": "Speed Queen",
@@ -8627,7 +8627,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/9c/Speed_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Speed_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Speed_Queen"
       },
       {
         "name": "Spirit Tortoise",
@@ -8640,7 +8640,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4d/Spirit_Tortoise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spirit_Tortoise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spirit_Tortoise"
       },
       {
         "name": "Sprite",
@@ -8653,7 +8653,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Sprite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sprite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sprite"
       },
       {
         "name": "Star Reader",
@@ -8666,7 +8666,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/91/Star_Reader.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Reader"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Reader"
       },
       {
         "name": "Sylph",
@@ -8679,7 +8679,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f4/Sylph.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sylph"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sylph"
       },
       {
         "name": "Table-Tennis Girl",
@@ -8692,7 +8692,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b3/Table-Tennis_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Table-Tennis_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Table-Tennis_Girl"
       },
       {
         "name": "The Poor",
@@ -8705,7 +8705,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/af/The_Poor_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/The_Poor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/The_Poor"
       },
       {
         "name": "Theologian",
@@ -8718,7 +8718,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7b/Theologian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Theologian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Theologian"
       },
       {
         "name": "Time Patrol",
@@ -8731,7 +8731,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/9f/Time_Patrol.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Time_Patrol"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Time_Patrol"
       },
       {
         "name": "Trops",
@@ -8744,7 +8744,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/42/Trops.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Trops"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Trops"
       },
       {
         "name": "Turmeric",
@@ -8757,7 +8757,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/40/Turmeric.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Turmeric"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Turmeric"
       },
       {
         "name": "Undine",
@@ -8770,7 +8770,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e6/Undine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Undine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Undine"
       },
       {
         "name": "Valefar",
@@ -8783,7 +8783,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/35/Valefar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valefar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valefar"
       },
       {
         "name": "Vampire Hunter",
@@ -8796,7 +8796,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c8/Vampire_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vampire_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vampire_Hunter"
       },
       {
         "name": "Verthandi",
@@ -8809,7 +8809,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/99/Verthandi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Verthandi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Verthandi"
       },
       {
         "name": "Warden",
@@ -8822,7 +8822,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Warden.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Warden"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Warden"
       },
       {
         "name": "Weapon Master",
@@ -8835,7 +8835,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1a/Weapon_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Weapon_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Weapon_Master"
       },
       {
         "name": "White Cat",
@@ -8848,7 +8848,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a2/White_Cat_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Cat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Cat"
       },
       {
         "name": "Woodland Maiden",
@@ -8861,7 +8861,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6d/Woodland_Maiden.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Woodland_Maiden"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Woodland_Maiden"
       },
       {
         "name": "Yukinnko",
@@ -8874,7 +8874,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4b/Yukinnko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yukinnko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yukinnko"
       },
       {
         "name": "2nd Hammer",
@@ -8887,7 +8887,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e6/2nd_Hammer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/2nd_Hammer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/2nd_Hammer"
       },
       {
         "name": "Afanc",
@@ -8900,7 +8900,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/83/Afanc.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Afanc"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Afanc"
       },
       {
         "name": "Agreas",
@@ -8913,7 +8913,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/da/Agreas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Agreas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Agreas"
       },
       {
         "name": "Akashic Record",
@@ -8930,7 +8930,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/39/Akashic_Record.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Akashic_Record"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Akashic_Record"
       },
       {
         "name": "Alecto",
@@ -8943,7 +8943,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Alecto.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alecto"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alecto"
       },
       {
         "name": "Alien",
@@ -8968,7 +8968,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/12/Alien.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien"
       },
       {
         "name": "Aludra",
@@ -8985,7 +8985,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/01/Aludra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aludra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aludra"
       },
       {
         "name": "Amefurashi",
@@ -8998,7 +8998,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0e/Amefurashi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amefurashi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amefurashi"
       },
       {
         "name": "Amore Tenderness",
@@ -9015,7 +9015,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/68/Amore_Tenderness_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amore_Tenderness"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amore_Tenderness"
       },
       {
         "name": "Angler",
@@ -9028,7 +9028,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bf/Angler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angler"
       },
       {
         "name": "Anne Bonny",
@@ -9041,7 +9041,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fe/Anne_Bonny.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anne_Bonny"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anne_Bonny"
       },
       {
         "name": "Aqua",
@@ -9054,7 +9054,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/44/Aqua.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aqua"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aqua"
       },
       {
         "name": "Arion",
@@ -9067,7 +9067,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/89/Arion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arion"
       },
       {
         "name": "Artemis",
@@ -9080,7 +9080,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d2/Artemis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Artemis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Artemis"
       },
       {
         "name": "Asherah",
@@ -9093,7 +9093,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/15/Asherah.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asherah"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asherah"
       },
       {
         "name": "Assault Reporter",
@@ -9110,7 +9110,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f7/Assault_Reporter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Assault_Reporter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Assault_Reporter"
       },
       {
         "name": "Atropos",
@@ -9123,7 +9123,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e2/Atropos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Atropos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Atropos"
       },
       {
         "name": "Aurora",
@@ -9136,7 +9136,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/89/Aurora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aurora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aurora"
       },
       {
         "name": "Azure Dragon",
@@ -9149,7 +9149,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cd/Azure_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Azure_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Azure_Dragon"
       },
       {
         "name": "Baena",
@@ -9162,7 +9162,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/57/Baena_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Baena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Baena"
       },
       {
         "name": "Barbatos",
@@ -9175,7 +9175,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f3/Barbatos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Barbatos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Barbatos"
       },
       {
         "name": "Brain Crusher",
@@ -9188,7 +9188,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e9/Brain_Crusher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brain_Crusher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brain_Crusher"
       },
       {
         "name": "Brush Master",
@@ -9205,7 +9205,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8e/Brush_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brush_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brush_Master"
       },
       {
         "name": "Capella",
@@ -9222,7 +9222,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9b/Capella.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Capella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Capella"
       },
       {
         "name": "Cetus",
@@ -9239,7 +9239,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/69/Cetus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cetus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cetus"
       },
       {
         "name": "Chaucer",
@@ -9256,7 +9256,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/94/Chaucer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chaucer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chaucer"
       },
       {
         "name": "Chess",
@@ -9269,7 +9269,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6f/Chess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chess"
       },
       {
         "name": "Clarice",
@@ -9286,7 +9286,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/09/Clarice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Clarice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Clarice"
       },
       {
         "name": "Consort Wu",
@@ -9299,7 +9299,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d1/Consort_Wu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Consort_Wu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Consort_Wu"
       },
       {
         "name": "Cool Fairy",
@@ -9312,7 +9312,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/6e/Cool_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cool_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cool_Fairy"
       },
       {
         "name": "Cora",
@@ -9325,7 +9325,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0a/Cora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cora"
       },
       {
         "name": "Cowardly Bellona",
@@ -9338,7 +9338,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/88/Cowardly_Bellona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cowardly_Bellona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cowardly_Bellona"
       },
       {
         "name": "Cthulhu",
@@ -9355,7 +9355,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9e/Cthulhu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cthulhu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cthulhu"
       },
       {
         "name": "Cyberwizard",
@@ -9368,7 +9368,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1a/Cyberwizard.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cyberwizard"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cyberwizard"
       },
       {
         "name": "Cyborg",
@@ -9381,7 +9381,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a3/Cyborg.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cyborg"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cyborg"
       },
       {
         "name": "Dantalion",
@@ -9398,7 +9398,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/78/Dantalion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dantalion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dantalion"
       },
       {
         "name": "Daredevil",
@@ -9415,7 +9415,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8f/Daredevil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Daredevil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Daredevil"
       },
       {
         "name": "Delice",
@@ -9432,7 +9432,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f1/Delice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Delice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Delice"
       },
       {
         "name": "Demon Summoner",
@@ -9445,7 +9445,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/9f/Demon_Summoner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demon_Summoner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demon_Summoner"
       },
       {
         "name": "Despoina",
@@ -9458,7 +9458,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/85/Despoina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Despoina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Despoina"
       },
       {
         "name": "Doll Princess",
@@ -9471,7 +9471,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3e/Doll_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doll_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doll_Princess"
       },
       {
         "name": "Dorothy",
@@ -9484,7 +9484,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8b/Dorothy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dorothy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dorothy"
       },
       {
         "name": "Dragon Princess",
@@ -9497,7 +9497,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6d/Dragon_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dragon_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dragon_Princess"
       },
       {
         "name": "Empress",
@@ -9510,7 +9510,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/12/Empress.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress"
       },
       {
         "name": "Eva",
@@ -9523,7 +9523,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1d/Eva.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eva"
       },
       {
         "name": "Fallen Samurai",
@@ -9536,7 +9536,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d6/Fallen_Samurai.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fallen_Samurai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fallen_Samurai"
       },
       {
         "name": "Finette",
@@ -9553,7 +9553,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2a/Finette.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Finette"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Finette"
       },
       {
         "name": "Flower Fairy",
@@ -9570,7 +9570,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c7/Flower_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flower_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flower_Fairy"
       },
       {
         "name": "Freshman Seven",
@@ -9587,7 +9587,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d0/Freshman_Seven.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Freshman_Seven"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Freshman_Seven"
       },
       {
         "name": "Frigg",
@@ -9604,7 +9604,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a2/Frigg.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Frigg"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Frigg"
       },
       {
         "name": "Frosty",
@@ -9617,7 +9617,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3d/Frosty.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Frosty"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Frosty"
       },
       {
         "name": "Gardener",
@@ -9630,7 +9630,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/19/Gardener.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gardener"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gardener"
       },
       {
         "name": "Gerhilde",
@@ -9647,7 +9647,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b4/Gerhilde.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gerhilde"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gerhilde"
       },
       {
         "name": "Gleipnir",
@@ -9660,7 +9660,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6e/Gleipnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gleipnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gleipnir"
       },
       {
         "name": "Gloriana",
@@ -9673,7 +9673,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/69/Gloriana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gloriana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gloriana"
       },
       {
         "name": "Gold Rush",
@@ -9686,7 +9686,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3d/Gold_Rush.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gold_Rush"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gold_Rush"
       },
       {
         "name": "Goldust",
@@ -9703,7 +9703,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/57/Goldust.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Goldust"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Goldust"
       },
       {
         "name": "Grumpy Princess",
@@ -9720,7 +9720,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dc/Grumpy_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Grumpy_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Grumpy_Princess"
       },
       {
         "name": "Gungnir",
@@ -9733,7 +9733,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5a/Gungnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gungnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gungnir"
       },
       {
         "name": "Harihara",
@@ -9746,7 +9746,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d2/Harihara.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Harihara"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Harihara"
       },
       {
         "name": "Headmaster",
@@ -9759,7 +9759,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/68/Headmaster.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Headmaster"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Headmaster"
       },
       {
         "name": "Hermes",
@@ -9776,7 +9776,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0d/Hermes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hermes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hermes"
       },
       {
         "name": "Hijack",
@@ -9789,7 +9789,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/26/Hijack.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hijack"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hijack"
       },
       {
         "name": "Himiko",
@@ -9806,7 +9806,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ec/Himiko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Himiko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Himiko"
       },
       {
         "name": "Huwawa",
@@ -9823,7 +9823,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0a/Huwawa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Huwawa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Huwawa"
       },
       {
         "name": "Infeliz",
@@ -9840,7 +9840,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/02/Infeliz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Infeliz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Infeliz"
       },
       {
         "name": "Jinn",
@@ -9853,7 +9853,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Jinn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jinn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jinn"
       },
       {
         "name": "Kagura",
@@ -9870,7 +9870,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/af/Kagura.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kagura"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kagura"
       },
       {
         "name": "Kayatsuhime",
@@ -9883,7 +9883,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/98/Kayatsuhime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kayatsuhime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kayatsuhime"
       },
       {
         "name": "Lagrasse",
@@ -9896,7 +9896,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4c/Lagrasse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lagrasse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lagrasse"
       },
       {
         "name": "Laperm",
@@ -9909,7 +9909,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0d/Laperm.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Laperm"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Laperm"
       },
       {
         "name": "Larxsus",
@@ -9926,7 +9926,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1d/Larxsus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Larxsus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Larxsus"
       },
       {
         "name": "Leviathan Ex",
@@ -9943,7 +9943,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Leviathan_Ex.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leviathan_Ex"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leviathan_Ex"
       },
       {
         "name": "Librarian",
@@ -9956,7 +9956,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/55/Librarian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Librarian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Librarian"
       },
       {
         "name": "Lina",
@@ -9969,7 +9969,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ec/Lina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lina"
       },
       {
         "name": "Lira",
@@ -9986,7 +9986,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c7/Lira.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lira"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lira"
       },
       {
         "name": "Love Succubus",
@@ -9999,7 +9999,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3c/Love_Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Love_Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Love_Succubus"
       },
       {
         "name": "Luce",
@@ -10016,7 +10016,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2b/Luce.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Luce"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Luce"
       },
       {
         "name": "Mahadevi",
@@ -10033,7 +10033,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2c/Mahadevi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mahadevi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mahadevi"
       },
       {
         "name": "Mahjong Champ",
@@ -10046,7 +10046,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f1/Mahjong_Champ.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mahjong_Champ"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mahjong_Champ"
       },
       {
         "name": "Maid Droid",
@@ -10063,7 +10063,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5c/Maid_Droid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maid_Droid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maid_Droid"
       },
       {
         "name": "Manager",
@@ -10080,7 +10080,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/15/Manager.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Manager"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Manager"
       },
       {
         "name": "Mani",
@@ -10097,7 +10097,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/eb/Mani.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mani"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mani"
       },
       {
         "name": "Matrix",
@@ -10110,7 +10110,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/84/Matrix.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Matrix"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Matrix"
       },
       {
         "name": "Mega Mover",
@@ -10127,7 +10127,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Mega_Mover.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mega_Mover"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mega_Mover"
       },
       {
         "name": "Melle",
@@ -10144,7 +10144,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/89/Melle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melle"
       },
       {
         "name": "Melty",
@@ -10157,7 +10157,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/80/Melty.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melty"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melty"
       },
       {
         "name": "Monochrome",
@@ -10170,7 +10170,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/15/Monochrome.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Monochrome"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Monochrome"
       },
       {
         "name": "Morgiana",
@@ -10183,7 +10183,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d5/Morgiana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morgiana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morgiana"
       },
       {
         "name": "Murakumo",
@@ -10196,7 +10196,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/08/Murakumo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Murakumo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Murakumo"
       },
       {
         "name": "Nakisawame",
@@ -10213,7 +10213,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/12/Nakisawame.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nakisawame"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nakisawame"
       },
       {
         "name": "Nemesis",
@@ -10226,7 +10226,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e3/Nemesis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nemesis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nemesis"
       },
       {
         "name": "Neptune",
@@ -10243,7 +10243,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/15/Neptune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Neptune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Neptune"
       },
       {
         "name": "Nott",
@@ -10260,7 +10260,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ef/Nott.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nott"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nott"
       },
       {
         "name": "Nuwa",
@@ -10273,7 +10273,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e6/Nuwa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nuwa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nuwa"
       },
       {
         "name": "Odysseus",
@@ -10286,7 +10286,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c2/Odysseus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Odysseus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Odysseus"
       },
       {
         "name": "Organo-Mechanic",
@@ -10303,7 +10303,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Organo-Mechanic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Organo-Mechanic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Organo-Mechanic"
       },
       {
         "name": "Orihime",
@@ -10320,7 +10320,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/65/Orihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Orihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Orihime"
       },
       {
         "name": "Ortlinde",
@@ -10337,7 +10337,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/86/Ortlinde.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ortlinde"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ortlinde"
       },
       {
         "name": "Paloma",
@@ -10350,7 +10350,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ee/Paloma.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paloma"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paloma"
       },
       {
         "name": "Paulina",
@@ -10363,7 +10363,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3d/Paulina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paulina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paulina"
       },
       {
         "name": "Pemphredo",
@@ -10376,7 +10376,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e8/Pemphredo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pemphredo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pemphredo"
       },
       {
         "name": "Petitrite",
@@ -10389,7 +10389,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fe/Petitrite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Petitrite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Petitrite"
       },
       {
         "name": "Phanuel",
@@ -10402,7 +10402,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/79/Phanuel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Phanuel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Phanuel"
       },
       {
         "name": "Philosopher",
@@ -10415,7 +10415,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e0/Philosopher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Philosopher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Philosopher"
       },
       {
         "name": "Pit Mechanic",
@@ -10428,7 +10428,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/20/Pit_Mechanic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pit_Mechanic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pit_Mechanic"
       },
       {
         "name": "Plantain Fan",
@@ -10441,7 +10441,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/27/Plantain_Fan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Plantain_Fan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Plantain_Fan"
       },
       {
         "name": "Poli'Ahu",
@@ -10454,7 +10454,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/67/Poli%27Ahu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Poli%27Ahu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Poli%27Ahu"
       },
       {
         "name": "Princess Kaguya",
@@ -10467,7 +10467,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e1/Princess_Kaguya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess_Kaguya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess_Kaguya"
       },
       {
         "name": "Prismatic Master",
@@ -10484,7 +10484,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1c/Prismatic_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Prismatic_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Prismatic_Master"
       },
       {
         "name": "Prydwen",
@@ -10497,7 +10497,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/88/Prydwen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Prydwen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Prydwen"
       },
       {
         "name": "Queen of Pirates",
@@ -10510,7 +10510,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/51/Queen_of_Pirates.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_of_Pirates"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_of_Pirates"
       },
       {
         "name": "Race Queen",
@@ -10523,7 +10523,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/9f/Race_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Race_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Race_Queen"
       },
       {
         "name": "Reverie",
@@ -10540,7 +10540,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/69/Reverie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Reverie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Reverie"
       },
       {
         "name": "Sacred Sol",
@@ -10557,7 +10557,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/69/Sacred_Sol.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacred_Sol"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacred_Sol"
       },
       {
         "name": "Saketoke",
@@ -10574,7 +10574,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c3/Saketoke.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saketoke"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saketoke"
       },
       {
         "name": "Sandalphon",
@@ -10587,7 +10587,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e2/Sandalphon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sandalphon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sandalphon"
       },
       {
         "name": "Sandy",
@@ -10600,7 +10600,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Sandy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sandy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sandy"
       },
       {
         "name": "Sania",
@@ -10613,7 +10613,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a5/Sania.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sania"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sania"
       },
       {
         "name": "Scarlet Hades",
@@ -10626,7 +10626,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Scarlet_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scarlet_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scarlet_Hades"
       },
       {
         "name": "Scue",
@@ -10639,7 +10639,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/aa/Scue.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scue"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scue"
       },
       {
         "name": "Seashell",
@@ -10656,7 +10656,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/eb/Seashell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Seashell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Seashell"
       },
       {
         "name": "Seducir",
@@ -10669,7 +10669,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/93/Seducir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Seducir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Seducir"
       },
       {
         "name": "Sekhmet",
@@ -10682,7 +10682,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9a/Sekhmet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sekhmet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sekhmet"
       },
       {
         "name": "Shelly",
@@ -10699,7 +10699,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3b/Shelly.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shelly"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shelly"
       },
       {
         "name": "Shennong",
@@ -10712,7 +10712,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/61/Shennong.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shennong"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shennong"
       },
       {
         "name": "Sigrun",
@@ -10729,7 +10729,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/65/Sigrun.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sigrun"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sigrun"
       },
       {
         "name": "Sinbad",
@@ -10746,7 +10746,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/35/Sinbad.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sinbad"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sinbad"
       },
       {
         "name": "Skadi",
@@ -10763,7 +10763,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2b/Skadi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skadi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skadi"
       },
       {
         "name": "Sky Navigator",
@@ -10776,7 +10776,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5a/Sky_Navigator.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sky_Navigator"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sky_Navigator"
       },
       {
         "name": "Snake Disciple",
@@ -10793,7 +10793,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/57/Snake_Disciple.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snake_Disciple"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snake_Disciple"
       },
       {
         "name": "Snow Demon",
@@ -10806,7 +10806,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/aa/Snow_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snow_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snow_Demon"
       },
       {
         "name": "Snowman MK II",
@@ -10819,7 +10819,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d2/Snowman_MK_II.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snowman_MK_II"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snowman_MK_II"
       },
       {
         "name": "Soleil",
@@ -10832,7 +10832,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/98/Soleil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soleil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soleil"
       },
       {
         "name": "Solomon",
@@ -10849,7 +10849,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/89/Solomon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Solomon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Solomon"
       },
       {
         "name": "Sonic Swordmaster",
@@ -10862,7 +10862,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/83/Sonic_Swordmaster.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sonic_Swordmaster"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sonic_Swordmaster"
       },
       {
         "name": "Soul Conductor",
@@ -10875,7 +10875,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/07/Soul_Conductor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soul_Conductor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soul_Conductor"
       },
       {
         "name": "Soul Dowser",
@@ -10892,7 +10892,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/17/Soul_Dowser.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soul_Dowser"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soul_Dowser"
       },
       {
         "name": "Spade",
@@ -10909,7 +10909,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8e/Spade.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spade"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spade"
       },
       {
         "name": "Strategist",
@@ -10922,7 +10922,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fa/Strategist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Strategist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Strategist"
       },
       {
         "name": "Stylist",
@@ -10935,7 +10935,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/16/Stylist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stylist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stylist"
       },
       {
         "name": "Sukis",
@@ -10948,7 +10948,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/28/Sukis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sukis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sukis"
       },
       {
         "name": "Super Chimry (Cool)",
@@ -10961,7 +10961,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7f/Super_Chimry_%28Cool%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Chimry_(Cool)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Chimry_(Cool)"
       },
       {
         "name": "Tenderness",
@@ -10978,7 +10978,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/ff/Tenderness.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tenderness"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tenderness"
       },
       {
         "name": "Teyr",
@@ -10995,7 +10995,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Teyr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teyr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teyr"
       },
       {
         "name": "Thermae",
@@ -11012,7 +11012,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b2/Thermae.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thermae"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thermae"
       },
       {
         "name": "Theseus",
@@ -11025,7 +11025,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Theseus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Theseus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Theseus"
       },
       {
         "name": "Thunderbolt",
@@ -11038,7 +11038,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/db/Thunderbolt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thunderbolt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thunderbolt"
       },
       {
         "name": "Thuries",
@@ -11055,7 +11055,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/80/Thuries.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thuries"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thuries"
       },
       {
         "name": "Tiger Hunter",
@@ -11068,7 +11068,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/83/Tiger_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tiger_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tiger_Hunter"
       },
       {
         "name": "Titan",
@@ -11081,7 +11081,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/88/Titan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Titan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Titan"
       },
       {
         "name": "Tovare",
@@ -11098,7 +11098,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d4/Tovare.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tovare"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tovare"
       },
       {
         "name": "Toyokumono",
@@ -11115,7 +11115,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3b/Toyokumono.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toyokumono"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toyokumono"
       },
       {
         "name": "True Lira",
@@ -11132,7 +11132,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/10/True_Lira_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Lira"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Lira"
       },
       {
         "name": "Tzitzimitl",
@@ -11149,7 +11149,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/02/Tzitzimitl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tzitzimitl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tzitzimitl"
       },
       {
         "name": "Ukanomitama",
@@ -11162,7 +11162,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/68/Ukanomitama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ukanomitama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ukanomitama"
       },
       {
         "name": "Umbrella Phantom",
@@ -11179,7 +11179,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/84/Umbrella_Phantom.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Umbrella_Phantom"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Umbrella_Phantom"
       },
       {
         "name": "Urcaguary",
@@ -11192,7 +11192,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4e/Urcaguary.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Urcaguary"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Urcaguary"
       },
       {
         "name": "Urcaguary Ex",
@@ -11205,7 +11205,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/75/Urcaguary_Ex.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Urcaguary_Ex"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Urcaguary_Ex"
       },
       {
         "name": "Vasariah",
@@ -11222,7 +11222,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/32/Vasariah.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vasariah"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vasariah"
       },
       {
         "name": "Vassago",
@@ -11235,7 +11235,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e2/Vassago.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vassago"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vassago"
       },
       {
         "name": "Warlord",
@@ -11248,7 +11248,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c8/Warlord.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Warlord"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Warlord"
       },
       {
         "name": "White Christmas",
@@ -11261,7 +11261,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/85/White_Christmas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Christmas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Christmas"
       },
       {
         "name": "White Night",
@@ -11278,7 +11278,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/95/White_Night.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Night"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Night"
       },
       {
         "name": "Winemaker",
@@ -11291,7 +11291,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cf/Winemaker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Winemaker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Winemaker"
       },
       {
         "name": "Wisp",
@@ -11304,7 +11304,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e7/Wisp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wisp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wisp"
       },
       {
         "name": "Wreath",
@@ -11317,7 +11317,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/de/Wreath.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wreath"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wreath"
       },
       {
         "name": "Wuxia",
@@ -11330,7 +11330,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/be/Wuxia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wuxia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wuxia"
       },
       {
         "name": "Yama",
@@ -11343,7 +11343,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/ba/Yama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yama"
       },
       {
         "name": "Yeti",
@@ -11356,7 +11356,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7d/Yeti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yeti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yeti"
       },
       {
         "name": "Zephyrus",
@@ -11373,7 +11373,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5a/Zephyrus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zephyrus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zephyrus"
       },
       {
         "name": "Zombina",
@@ -11386,7 +11386,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f9/Zombina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zombina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zombina"
       },
       {
         "name": "Zver",
@@ -11403,7 +11403,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f3/Zver.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zver"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zver"
       },
       {
         "name": "Adele",
@@ -11420,7 +11420,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Adele.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Adele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Adele"
       },
       {
         "name": "Alien Id",
@@ -11437,7 +11437,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4c/Alien_Id.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Id"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Id"
       },
       {
         "name": "Alien Ildanach",
@@ -11454,7 +11454,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/18/Alien_Ildanach.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Ildanach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Ildanach"
       },
       {
         "name": "Alsvior",
@@ -11471,7 +11471,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c0/Alsvior.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alsvior"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alsvior"
       },
       {
         "name": "Amatsukami",
@@ -11488,7 +11488,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/99/Amatsukami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amatsukami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amatsukami"
       },
       {
         "name": "Amore Charlotta",
@@ -11505,7 +11505,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Amore_Charlotta_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amore_Charlotta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amore_Charlotta"
       },
       {
         "name": "Amore Kukurihime",
@@ -11518,7 +11518,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3d/Amore_Kukurihime_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amore_Kukurihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amore_Kukurihime"
       },
       {
         "name": "Amore Timah",
@@ -11535,7 +11535,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ef/Amore_Timah_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amore_Timah"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amore_Timah"
       },
       {
         "name": "Anchor",
@@ -11552,7 +11552,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c0/Anchor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anchor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anchor"
       },
       {
         "name": "Anemone",
@@ -11569,7 +11569,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b1/Anemone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anemone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anemone"
       },
       {
         "name": "Arethusa",
@@ -11586,7 +11586,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/24/Arethusa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arethusa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arethusa"
       },
       {
         "name": "Ariadne",
@@ -11603,7 +11603,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/dd/Ariadne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ariadne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ariadne"
       },
       {
         "name": "Ariton",
@@ -11620,7 +11620,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/43/Ariton.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ariton"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ariton"
       },
       {
         "name": "Arvakr",
@@ -11637,7 +11637,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c5/Arvakr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arvakr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arvakr"
       },
       {
         "name": "Asterisk",
@@ -11654,7 +11654,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b3/Asterisk.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asterisk"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asterisk"
       },
       {
         "name": "Asura",
@@ -11675,7 +11675,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/52/Asura.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asura"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asura"
       },
       {
         "name": "Ate",
@@ -11692,7 +11692,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b0/Ate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ate"
       },
       {
         "name": "Balancer",
@@ -11709,7 +11709,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4d/Balancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balancer"
       },
       {
         "name": "Barakiel",
@@ -11726,7 +11726,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/87/Barakiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Barakiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Barakiel"
       },
       {
         "name": "Benzaiten",
@@ -11743,7 +11743,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c9/Benzaiten.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Benzaiten"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Benzaiten"
       },
       {
         "name": "Bewitching Lilith",
@@ -11756,7 +11756,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/22/Bewitching_Lilith_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bewitching_Lilith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bewitching_Lilith"
       },
       {
         "name": "Blade Dragon",
@@ -11773,7 +11773,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e9/Blade_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blade_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blade_Dragon"
       },
       {
         "name": "Boreas",
@@ -11790,7 +11790,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0d/Boreas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Boreas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Boreas"
       },
       {
         "name": "Captain Ducky",
@@ -11807,7 +11807,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/28/Captain_Ducky.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Ducky"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Ducky"
       },
       {
         "name": "Chainsaw Girl",
@@ -11824,7 +11824,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b2/Chainsaw_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chainsaw_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chainsaw_Girl"
       },
       {
         "name": "Chalcedony",
@@ -11841,7 +11841,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7c/Chalcedony.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chalcedony"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chalcedony"
       },
       {
         "name": "Chale",
@@ -11862,7 +11862,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5d/Chale.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chale"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chale"
       },
       {
         "name": "Charlotta",
@@ -11879,7 +11879,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/55/Charlotta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Charlotta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Charlotta"
       },
       {
         "name": "Charon",
@@ -11896,7 +11896,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e2/Charon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Charon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Charon"
       },
       {
         "name": "Chase",
@@ -11913,7 +11913,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c2/Chase.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chase"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chase"
       },
       {
         "name": "Chief Gatekeeper",
@@ -11930,7 +11930,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/20/Chief_Gatekeeper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chief_Gatekeeper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chief_Gatekeeper"
       },
       {
         "name": "Chione",
@@ -11947,7 +11947,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2a/Chione.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chione"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chione"
       },
       {
         "name": "Chocolatier",
@@ -11964,7 +11964,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b7/Chocolatier.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocolatier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocolatier"
       },
       {
         "name": "Cielo Llena",
@@ -11981,7 +11981,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/78/Cielo_Llena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cielo_Llena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cielo_Llena"
       },
       {
         "name": "Claire",
@@ -11998,7 +11998,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e5/Claire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Claire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Claire"
       },
       {
         "name": "Cleopatra",
@@ -12019,7 +12019,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b0/Cleopatra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cleopatra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cleopatra"
       },
       {
         "name": "Clockmaker",
@@ -12036,7 +12036,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/74/Clockmaker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Clockmaker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Clockmaker"
       },
       {
         "name": "Coalminer",
@@ -12053,7 +12053,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/50/Coalminer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Coalminer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Coalminer"
       },
       {
         "name": "Colobockle",
@@ -12070,7 +12070,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/cd/Colobockle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Colobockle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Colobockle"
       },
       {
         "name": "Coral",
@@ -12087,7 +12087,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b1/Coral.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Coral"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Coral"
       },
       {
         "name": "Cornelia",
@@ -12104,7 +12104,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3b/Cornelia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cornelia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cornelia"
       },
       {
         "name": "Couverture",
@@ -12125,7 +12125,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/16/Couverture.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Couverture"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Couverture"
       },
       {
         "name": "Dainsleif",
@@ -12142,7 +12142,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/31/Dainsleif.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dainsleif"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dainsleif"
       },
       {
         "name": "Daisy",
@@ -12159,7 +12159,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c1/Daisy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Daisy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Daisy"
       },
       {
         "name": "Dark Succubus",
@@ -12180,7 +12180,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b5/Dark_Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Succubus"
       },
       {
         "name": "Dark Tome Mia",
@@ -12197,7 +12197,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7e/Dark_Tome_Mia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Tome_Mia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Tome_Mia"
       },
       {
         "name": "Delusion",
@@ -12214,7 +12214,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/39/Delusion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Delusion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Delusion"
       },
       {
         "name": "Demogorgon",
@@ -12231,7 +12231,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bb/Demogorgon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demogorgon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demogorgon"
       },
       {
         "name": "Dimension Girl",
@@ -12248,7 +12248,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/19/Dimension_Girl_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dimension_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dimension_Girl"
       },
       {
         "name": "Dong Zhuo",
@@ -12265,7 +12265,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c3/Dong_Zhuo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dong_Zhuo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dong_Zhuo"
       },
       {
         "name": "Dragon Goddess",
@@ -12282,7 +12282,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d9/Dragon_Goddess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dragon_Goddess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dragon_Goddess"
       },
       {
         "name": "Draupnir",
@@ -12299,7 +12299,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2c/Draupnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Draupnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Draupnir"
       },
       {
         "name": "Dream Phantom",
@@ -12316,7 +12316,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4c/Dream_Phantom.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dream_Phantom"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dream_Phantom"
       },
       {
         "name": "Drink Master",
@@ -12333,7 +12333,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f5/Drink_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Drink_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Drink_Master"
       },
       {
         "name": "Dynamite Cheer",
@@ -12350,7 +12350,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3f/Dynamite_Cheer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dynamite_Cheer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dynamite_Cheer"
       },
       {
         "name": "Dver",
@@ -12367,7 +12367,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a4/Dver.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dver"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dver"
       },
       {
         "name": "Dynatos Theseus",
@@ -12384,7 +12384,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/33/Dynatos_Theseus_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dynatos_Theseus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dynatos_Theseus"
       },
       {
         "name": "Eb-2",
@@ -12401,7 +12401,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b0/Eb-2.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eb-2"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eb-2"
       },
       {
         "name": "Eb-2 Custom",
@@ -12418,7 +12418,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d7/Eb-2_Custom_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eb-2_Custom"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eb-2_Custom"
       },
       {
         "name": "Eden Maker",
@@ -12435,7 +12435,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e5/Eden_Maker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eden_Maker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eden_Maker"
       },
       {
         "name": "Elemental Queen",
@@ -12452,7 +12452,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cc/Elemental_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elemental_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elemental_Queen"
       },
       {
         "name": "Ethnia",
@@ -12469,7 +12469,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/00/Ethnia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ethnia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ethnia"
       },
       {
         "name": "Fallen Angel",
@@ -12490,7 +12490,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1d/Fallen_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fallen_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fallen_Angel"
       },
       {
         "name": "Faure",
@@ -12507,7 +12507,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9b/Faure.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Faure"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Faure"
       },
       {
         "name": "Fenrir",
@@ -12524,7 +12524,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6a/Fenrir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fenrir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fenrir"
       },
       {
         "name": "Fleurety",
@@ -12541,7 +12541,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/31/Fleurety.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fleurety"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fleurety"
       },
       {
         "name": "Flower Murakumo",
@@ -12558,7 +12558,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1e/Flower_Murakumo_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flower_Murakumo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flower_Murakumo"
       },
       {
         "name": "Flower Potter",
@@ -12575,7 +12575,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/73/Flower_Potter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flower_Potter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flower_Potter"
       },
       {
         "name": "Folk Singer",
@@ -12600,7 +12600,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/ac/Folk_Singer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Folk_Singer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Folk_Singer"
       },
       {
         "name": "Formal Sucia",
@@ -12613,7 +12613,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/da/Formal_Sucia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Formal_Sucia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Formal_Sucia"
       },
       {
         "name": "Foxie",
@@ -12630,7 +12630,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f7/Foxie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Foxie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Foxie"
       },
       {
         "name": "Fu Xi",
@@ -12651,7 +12651,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4d/Fu_Xi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fu_Xi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fu_Xi"
       },
       {
         "name": "Fujisan",
@@ -12668,7 +12668,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1e/Fujisan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fujisan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fujisan"
       },
       {
         "name": "Furious Chase",
@@ -12685,7 +12685,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e5/Furious_Chase_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furious_Chase"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furious_Chase"
       },
       {
         "name": "Garden Guardian",
@@ -12702,7 +12702,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/50/Garden_Guardian_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Garden_Guardian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Garden_Guardian"
       },
       {
         "name": "Garm",
@@ -12719,7 +12719,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/90/Garm.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Garm"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Garm"
       },
       {
         "name": "Guardian Licorice",
@@ -12736,7 +12736,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1a/Guardian_Licorice_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Guardian_Licorice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Guardian_Licorice"
       },
       {
         "name": "Helen",
@@ -12753,7 +12753,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/83/Helen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Helen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Helen"
       },
       {
         "name": "Herb Stolas",
@@ -12770,7 +12770,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fd/Herb_Stolas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Herb_Stolas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Herb_Stolas"
       },
       {
         "name": "Herb Wing",
@@ -12783,7 +12783,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4b/Herb_Wing_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Herb_Wing"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Herb_Wing"
       },
       {
         "name": "Hijiri-No-Kami",
@@ -12800,7 +12800,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/47/Hijiri-No-Kami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hijiri-No-Kami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hijiri-No-Kami"
       },
       {
         "name": "Hyakki Yagyo",
@@ -12817,7 +12817,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/80/Hyakki_Yagyo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyakki_Yagyo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyakki_Yagyo"
       },
       {
         "name": "Hyper Chimry (Cool)",
@@ -12830,7 +12830,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4b/Hyper_Chimry_%28Cool%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Chimry_(Cool)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Chimry_(Cool)"
       },
       {
         "name": "Ice Wolf Skoll",
@@ -12847,7 +12847,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/ca/Ice_Wolf_Skoll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ice_Wolf_Skoll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ice_Wolf_Skoll"
       },
       {
         "name": "Icicle",
@@ -12864,7 +12864,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/23/Icicle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Icicle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Icicle"
       },
       {
         "name": "Iwanagahime",
@@ -12881,7 +12881,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3d/Iwanagahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Iwanagahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Iwanagahime"
       },
       {
         "name": "Jack o' Lantern",
@@ -12898,7 +12898,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/26/Jack_o%27_Lantern.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jack_o%27_Lantern"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jack_o%27_Lantern"
       },
       {
         "name": "Kaede",
@@ -12915,7 +12915,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f0/Kaede.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kaede"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kaede"
       },
       {
         "name": "Kanaloa",
@@ -12932,7 +12932,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d5/Kanaloa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kanaloa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kanaloa"
       },
       {
         "name": "Katrina",
@@ -12949,7 +12949,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/75/Katrina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Katrina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Katrina"
       },
       {
         "name": "Kericoff",
@@ -12966,7 +12966,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/34/Kericoff.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kericoff"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kericoff"
       },
       {
         "name": "Knishka",
@@ -12983,7 +12983,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f7/Knishka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Knishka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Knishka"
       },
       {
         "name": "Krueger",
@@ -13000,7 +13000,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/02/Krueger.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Krueger"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Krueger"
       },
       {
         "name": "Kukurihime",
@@ -13017,7 +13017,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/da/Kukurihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kukurihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kukurihime"
       },
       {
         "name": "Lady Spinel",
@@ -13034,7 +13034,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/22/Lady_Spinel_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lady_Spinel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lady_Spinel"
       },
       {
         "name": "Landscaper",
@@ -13051,7 +13051,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Landscaper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Landscaper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Landscaper"
       },
       {
         "name": "Leona",
@@ -13068,7 +13068,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9a/Leona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leona"
       },
       {
         "name": "Licorice",
@@ -13085,7 +13085,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a9/Licorice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Licorice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Licorice"
       },
       {
         "name": "Lilith",
@@ -13102,7 +13102,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7e/Lilith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lilith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lilith"
       },
       {
         "name": "Linus",
@@ -13119,7 +13119,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/31/Linus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Linus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Linus"
       },
       {
         "name": "Longinus",
@@ -13136,7 +13136,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/20/Longinus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Longinus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Longinus"
       },
       {
         "name": "Loreley",
@@ -13153,7 +13153,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2c/Loreley.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Loreley"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Loreley"
       },
       {
         "name": "Luna Llena",
@@ -13170,7 +13170,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1d/Luna_Llena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Luna_Llena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Luna_Llena"
       },
       {
         "name": "Mad Scientist",
@@ -13187,7 +13187,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1a/Mad_Scientist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mad_Scientist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mad_Scientist"
       },
       {
         "name": "Maeve",
@@ -13204,7 +13204,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bf/Maeve.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maeve"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maeve"
       },
       {
         "name": "Marici",
@@ -13221,7 +13221,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7b/Marici.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Marici"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Marici"
       },
       {
         "name": "Master Sparky",
@@ -13234,7 +13234,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f4/Master_Sparky_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Master_Sparky"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Master_Sparky"
       },
       {
         "name": "Minister Sucia",
@@ -13251,7 +13251,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f5/Minister_Sucia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minister_Sucia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minister_Sucia"
       },
       {
         "name": "Mithra",
@@ -13268,7 +13268,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/02/Mithra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mithra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mithra"
       },
       {
         "name": "Molly",
@@ -13285,7 +13285,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/04/Molly.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Molly"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Molly"
       },
       {
         "name": "Neos",
@@ -13302,7 +13302,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/78/Neos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Neos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Neos"
       },
       {
         "name": "Netherworld Princess",
@@ -13319,7 +13319,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Netherworld_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Netherworld_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Netherworld_Princess"
       },
       {
         "name": "Nighttime Beach",
@@ -13336,7 +13336,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/76/Nighttime_Beach.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nighttime_Beach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nighttime_Beach"
       },
       {
         "name": "Ninlil",
@@ -13353,7 +13353,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9b/Ninlil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ninlil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ninlil"
       },
       {
         "name": "Oracle Ascendant",
@@ -13370,7 +13370,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/56/Oracle_Ascendant.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oracle_Ascendant"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oracle_Ascendant"
       },
       {
         "name": "Orbit",
@@ -13387,7 +13387,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a2/Orbit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Orbit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Orbit"
       },
       {
         "name": "Otherworld Girl",
@@ -13404,7 +13404,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/53/Otherworld_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Otherworld_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Otherworld_Girl"
       },
       {
         "name": "Ox King",
@@ -13421,7 +13421,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/9f/Ox_King.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ox_King"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ox_King"
       },
       {
         "name": "Paimon",
@@ -13438,7 +13438,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b4/Paimon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paimon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paimon"
       },
       {
         "name": "Parade Keeper",
@@ -13455,7 +13455,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0e/Parade_Keeper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Parade_Keeper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Parade_Keeper"
       },
       {
         "name": "Party Crasher",
@@ -13472,7 +13472,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6a/Party_Crasher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Party_Crasher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Party_Crasher"
       },
       {
         "name": "Peony",
@@ -13489,7 +13489,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/50/Peony.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Peony"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Peony"
       },
       {
         "name": "Perchta",
@@ -13506,7 +13506,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6c/Perchta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Perchta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Perchta"
       },
       {
         "name": "Persona",
@@ -13523,7 +13523,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f3/Persona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Persona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Persona"
       },
       {
         "name": "Phantom X",
@@ -13540,7 +13540,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5a/Phantom_X.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Phantom_X"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Phantom_X"
       },
       {
         "name": "Pixie Cup",
@@ -13557,7 +13557,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c9/Pixie_Cup.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pixie_Cup"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pixie_Cup"
       },
       {
         "name": "Playful Hades (Blue)",
@@ -13574,7 +13574,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6d/Playful_Hades_%28Blue%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Playful_Hades_(Blue)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Playful_Hades_(Blue)"
       },
       {
         "name": "Playful Hades (Green)",
@@ -13591,7 +13591,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e3/Playful_Hades_%28Green%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Playful_Hades_(Green)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Playful_Hades_(Green)"
       },
       {
         "name": "Playful Hades (Red)",
@@ -13608,7 +13608,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Playful_Hades_%28Red%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Playful_Hades_(Red)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Playful_Hades_(Red)"
       },
       {
         "name": "Princess Black Rose",
@@ -13625,7 +13625,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7e/Princess_Black_Rose.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess_Black_Rose"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess_Black_Rose"
       },
       {
         "name": "Princess Longji",
@@ -13642,7 +13642,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6e/Princess_Longji.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess_Longji"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess_Longji"
       },
       {
         "name": "Pup",
@@ -13659,7 +13659,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/61/Pup.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pup"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pup"
       },
       {
         "name": "Qlipha",
@@ -13676,7 +13676,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a8/Qlipha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Qlipha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Qlipha"
       },
       {
         "name": "Regea",
@@ -13693,7 +13693,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e1/Regea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Regea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Regea"
       },
       {
         "name": "Rex Luna Llena",
@@ -13710,7 +13710,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/96/Rex_Luna_Llena_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rex_Luna_Llena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rex_Luna_Llena"
       },
       {
         "name": "Rich Girl",
@@ -13727,7 +13727,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/fd/Rich_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rich_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rich_Girl"
       },
       {
         "name": "Roche",
@@ -13744,7 +13744,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/13/Roche.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roche"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roche"
       },
       {
         "name": "Santa Perchta",
@@ -13757,7 +13757,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/54/Santa_Perchta_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santa_Perchta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santa_Perchta"
       },
       {
         "name": "Sasha",
@@ -13774,7 +13774,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/04/Sasha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sasha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sasha"
       },
       {
         "name": "Sentinel Adele",
@@ -13787,7 +13787,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/98/Sentinel_Adele_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sentinel_Adele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sentinel_Adele"
       },
       {
         "name": "Setsuna",
@@ -13804,7 +13804,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3c/Setsuna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Setsuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Setsuna"
       },
       {
         "name": "Sfera",
@@ -13825,7 +13825,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/29/Sfera.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sfera"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sfera"
       },
       {
         "name": "Sky Traveler",
@@ -13842,7 +13842,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b9/Sky_Traveler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sky_Traveler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sky_Traveler"
       },
       {
         "name": "Smithy",
@@ -13859,7 +13859,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b9/Smithy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Smithy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Smithy"
       },
       {
         "name": "Snow Bunny",
@@ -13876,7 +13876,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/02/Snow_Bunny.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snow_Bunny"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snow_Bunny"
       },
       {
         "name": "Sparky (New)",
@@ -13893,7 +13893,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d8/Sparky_%28New%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sparky_(New)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sparky_(New)"
       },
       {
         "name": "Spell Master",
@@ -13910,7 +13910,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e8/Spell_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spell_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spell_Master"
       },
       {
         "name": "Spinel",
@@ -13927,7 +13927,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e7/Spinel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spinel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spinel"
       },
       {
         "name": "Suiren",
@@ -13944,7 +13944,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e4/Suiren.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Suiren"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Suiren"
       },
       {
         "name": "Summer Hades",
@@ -13961,7 +13961,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fa/Summer_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Summer_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Summer_Hades"
       },
       {
         "name": "Summer Snow",
@@ -13982,7 +13982,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/30/Summer_Snow.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Summer_Snow"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Summer_Snow"
       },
       {
         "name": "Sundered Spirit",
@@ -13999,7 +13999,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0f/Sundered_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sundered_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sundered_Spirit"
       },
       {
         "name": "Table Master",
@@ -14016,7 +14016,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a4/Table_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Table_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Table_Master"
       },
       {
         "name": "Takemikazuchi",
@@ -14033,7 +14033,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1e/Takemikazuchi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Takemikazuchi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Takemikazuchi"
       },
       {
         "name": "Teleios Theseus",
@@ -14050,7 +14050,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/51/Teleios_Theseus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teleios_Theseus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teleios_Theseus"
       },
       {
         "name": "Therese",
@@ -14063,7 +14063,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/20/Therese_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Therese"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Therese"
       },
       {
         "name": "Thesmophoros",
@@ -14080,7 +14080,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d5/Thesmophoros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thesmophoros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thesmophoros"
       },
       {
         "name": "Tiberius",
@@ -14097,7 +14097,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9c/Tiberius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tiberius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tiberius"
       },
       {
         "name": "Timah",
@@ -14114,7 +14114,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/48/Timah.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Timah"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Timah"
       },
       {
         "name": "Torpedo Girl",
@@ -14131,7 +14131,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/af/Torpedo_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Torpedo_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Torpedo_Girl"
       },
       {
         "name": "Trick Chain",
@@ -14148,7 +14148,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/28/Trick_Chain.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Trick_Chain"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Trick_Chain"
       },
       {
         "name": "True Daisy",
@@ -14165,7 +14165,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6e/True_Daisy_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Daisy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Daisy"
       },
       {
         "name": "True Murakumo",
@@ -14182,7 +14182,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/True_Murakumo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Murakumo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Murakumo"
       },
       {
         "name": "True Peony",
@@ -14199,7 +14199,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/14/True_Peony_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Peony"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Peony"
       },
       {
         "name": "True Tome Mia",
@@ -14216,7 +14216,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/True_Tome_Mia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Tome_Mia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Tome_Mia"
       },
       {
         "name": "Tsuchinoko",
@@ -14233,7 +14233,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fd/Tsuchinoko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tsuchinoko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tsuchinoko"
       },
       {
         "name": "Tsukuyomi",
@@ -14250,7 +14250,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/14/Tsukuyomi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tsukuyomi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tsukuyomi"
       },
       {
         "name": "Urania",
@@ -14267,7 +14267,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ed/Urania.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Urania"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Urania"
       },
       {
         "name": "Vaan",
@@ -14284,7 +14284,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b2/Vaan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vaan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vaan"
       },
       {
         "name": "Valiant Bellona",
@@ -14301,7 +14301,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ec/Valiant_Bellona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valiant_Bellona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valiant_Bellona"
       },
       {
         "name": "Valiant Bellona (Bronze)",
@@ -14314,7 +14314,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/78/Valiant_Bellona_%28Bronze%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valiant_Bellona_(Bronze)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valiant_Bellona_(Bronze)"
       },
       {
         "name": "Valiant Bellona (Gold)",
@@ -14327,7 +14327,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ea/Valiant_Bellona_%28Gold%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valiant_Bellona_(Gold)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valiant_Bellona_(Gold)"
       },
       {
         "name": "Valiant Bellona (Silver)",
@@ -14340,7 +14340,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/08/Valiant_Bellona_%28Silver%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valiant_Bellona_(Silver)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valiant_Bellona_(Silver)"
       },
       {
         "name": "Villa",
@@ -14357,7 +14357,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bc/Villa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Villa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Villa"
       },
       {
         "name": "White Crane",
@@ -14374,7 +14374,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e6/White_Crane.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Crane"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Crane"
       },
       {
         "name": "White Owl",
@@ -14391,7 +14391,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ee/White_Owl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Owl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Owl"
       },
       {
         "name": "White Russian",
@@ -14408,7 +14408,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d4/White_Russian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Russian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Russian"
       },
       {
         "name": "Wind Cave",
@@ -14425,7 +14425,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/46/Wind_Cave.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wind_Cave"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wind_Cave"
       },
       {
         "name": "Windup",
@@ -14450,7 +14450,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f3/Windup.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Windup"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Windup"
       },
       {
         "name": "Wirbel",
@@ -14467,7 +14467,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7e/Wirbel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wirbel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wirbel"
       },
       {
         "name": "Ying Long",
@@ -14484,7 +14484,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/25/Ying_Long.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ying_Long"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ying_Long"
       },
       {
         "name": "Arava",
@@ -14509,7 +14509,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6c/Arava.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arava"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arava"
       },
       {
         "name": "Azurite",
@@ -14534,7 +14534,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ee/Azurite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Azurite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Azurite"
       },
       {
         "name": "Bright Amaterasu",
@@ -14559,7 +14559,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d9/Bright_Amaterasu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bright_Amaterasu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bright_Amaterasu"
       },
       {
         "name": "Divine Murakumo",
@@ -14584,7 +14584,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a3/Divine_Murakumo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Murakumo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Murakumo"
       },
       {
         "name": "Egeria",
@@ -14609,7 +14609,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Egeria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Egeria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Egeria"
       },
       {
         "name": "Hiraga The Great",
@@ -14634,7 +14634,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/79/Hiraga_The_Great.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hiraga_The_Great"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hiraga_The_Great"
       },
       {
         "name": "Holy Angel",
@@ -14659,7 +14659,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/83/Holy_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Holy_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Holy_Angel"
       },
       {
         "name": "Krene",
@@ -14684,7 +14684,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c0/Krene.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Krene"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Krene"
       },
       {
         "name": "Lord Leviathan",
@@ -14709,7 +14709,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3b/Lord_Leviathan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lord_Leviathan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lord_Leviathan"
       },
       {
         "name": "Magatsuhi",
@@ -14734,7 +14734,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6d/Magatsuhi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Magatsuhi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Magatsuhi"
       },
       {
         "name": "Queen Bahamut",
@@ -14759,7 +14759,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f7/Queen_Bahamut.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Bahamut"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Bahamut"
       },
       {
         "name": "Regal Huang Long",
@@ -14784,7 +14784,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/91/Regal_Huang_Long.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Regal_Huang_Long"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Regal_Huang_Long"
       },
       {
         "name": "Sellana",
@@ -14809,7 +14809,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/36/Sellana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sellana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sellana"
       },
       {
         "name": "Aaron",
@@ -14822,7 +14822,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a8/Aaron.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aaron"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aaron"
       },
       {
         "name": "Acolyte",
@@ -14835,7 +14835,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c2/Acolyte.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Acolyte"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Acolyte"
       },
       {
         "name": "Agent Nine",
@@ -14848,7 +14848,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/12/Agent_Nine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Agent_Nine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Agent_Nine"
       },
       {
         "name": "Akito",
@@ -14861,7 +14861,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b3/Akito.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Akito"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Akito"
       },
       {
         "name": "Amp",
@@ -14874,7 +14874,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f8/Amp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amp"
       },
       {
         "name": "Analyst",
@@ -14887,7 +14887,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d4/Analyst.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Analyst"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Analyst"
       },
       {
         "name": "Angel",
@@ -14900,7 +14900,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/83/Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angel"
       },
       {
         "name": "Anubis",
@@ -14913,7 +14913,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/26/Anubis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anubis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anubis"
       },
       {
         "name": "Appraiser",
@@ -14926,7 +14926,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f0/Appraiser.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Appraiser"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Appraiser"
       },
       {
         "name": "Arch Knight",
@@ -14939,7 +14939,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3b/Arch_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arch_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arch_Knight"
       },
       {
         "name": "Avacyn",
@@ -14952,7 +14952,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/26/Avacyn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Avacyn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Avacyn"
       },
       {
         "name": "Betelgeuse",
@@ -14965,7 +14965,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ac/Betelgeuse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Betelgeuse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Betelgeuse"
       },
       {
         "name": "Bingo Girl",
@@ -14978,7 +14978,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/47/Bingo_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bingo_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bingo_Girl"
       },
       {
         "name": "Brunhild",
@@ -14991,7 +14991,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/38/Brunhild.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brunhild"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brunhild"
       },
       {
         "name": "Cecht",
@@ -15004,7 +15004,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d2/Cecht.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cecht"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cecht"
       },
       {
         "name": "Chimney Sweep",
@@ -15017,7 +15017,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b4/Chimney_Sweep.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chimney_Sweep"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chimney_Sweep"
       },
       {
         "name": "Choco Knight",
@@ -15030,7 +15030,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/96/Choco_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Choco_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Choco_Knight"
       },
       {
         "name": "Choirgirl",
@@ -15043,7 +15043,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/31/Choirgirl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Choirgirl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Choirgirl"
       },
       {
         "name": "Cinderella",
@@ -15056,7 +15056,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/07/Cinderella.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cinderella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cinderella"
       },
       {
         "name": "Coronis",
@@ -15069,7 +15069,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/37/Coronis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Coronis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Coronis"
       },
       {
         "name": "Court Lady",
@@ -15082,7 +15082,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a4/Court_Lady.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Court_Lady"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Court_Lady"
       },
       {
         "name": "Crescent Moon",
@@ -15095,7 +15095,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e7/Crescent_Moon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crescent_Moon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crescent_Moon"
       },
       {
         "name": "Crown Guard",
@@ -15108,7 +15108,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fa/Crown_Guard.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crown_Guard"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crown_Guard"
       },
       {
         "name": "Danda-Chakra",
@@ -15121,7 +15121,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/89/Danda-Chakra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Danda-Chakra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Danda-Chakra"
       },
       {
         "name": "Daphne",
@@ -15134,7 +15134,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ec/Daphne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Daphne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Daphne"
       },
       {
         "name": "Dike",
@@ -15147,7 +15147,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/72/Dike.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dike"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dike"
       },
       {
         "name": "Dione",
@@ -15160,7 +15160,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b6/Dione.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dione"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dione"
       },
       {
         "name": "Druid",
@@ -15173,7 +15173,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9d/Druid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Druid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Druid"
       },
       {
         "name": "Fabric Master",
@@ -15186,7 +15186,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/96/Fabric_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fabric_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fabric_Master"
       },
       {
         "name": "Flamel",
@@ -15199,7 +15199,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1a/Flamel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flamel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flamel"
       },
       {
         "name": "Galactic Conductor",
@@ -15212,7 +15212,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0d/Galactic_Conductor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Galactic_Conductor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Galactic_Conductor"
       },
       {
         "name": "Gale",
@@ -15225,7 +15225,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a0/Gale_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gale"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gale"
       },
       {
         "name": "Ghost Girl",
@@ -15238,7 +15238,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/53/Ghost_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghost_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghost_Girl"
       },
       {
         "name": "Ginger",
@@ -15251,7 +15251,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/85/Ginger.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ginger"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ginger"
       },
       {
         "name": "Grace",
@@ -15264,7 +15264,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/17/Grace.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Grace"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Grace"
       },
       {
         "name": "Guardian",
@@ -15277,7 +15277,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3b/Guardian_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Guardian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Guardian"
       },
       {
         "name": "Gummy Candy",
@@ -15290,7 +15290,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/88/Gummy_Candy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gummy_Candy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gummy_Candy"
       },
       {
         "name": "Hakutaku",
@@ -15303,7 +15303,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/17/Hakutaku.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hakutaku"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hakutaku"
       },
       {
         "name": "Hastur",
@@ -15316,7 +15316,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/27/Hastur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hastur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hastur"
       },
       {
         "name": "Hathor",
@@ -15329,7 +15329,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7a/Hathor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hathor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hathor"
       },
       {
         "name": "Humanoid",
@@ -15342,7 +15342,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fc/Humanoid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Humanoid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Humanoid"
       },
       {
         "name": "Io",
@@ -15355,7 +15355,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/94/Io.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Io"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Io"
       },
       {
         "name": "Isabel",
@@ -15368,7 +15368,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7e/Isabel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Isabel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Isabel"
       },
       {
         "name": "Isis",
@@ -15381,7 +15381,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/12/Isis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Isis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Isis"
       },
       {
         "name": "Judge",
@@ -15394,7 +15394,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8a/Judge.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Judge"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Judge"
       },
       {
         "name": "Kagamimochi",
@@ -15407,7 +15407,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a1/Kagamimochi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kagamimochi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kagamimochi"
       },
       {
         "name": "Kesalan Patharan",
@@ -15420,7 +15420,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8e/Kesalan_Patharan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kesalan_Patharan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kesalan_Patharan"
       },
       {
         "name": "Knight",
@@ -15433,7 +15433,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6b/Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Knight"
       },
       {
         "name": "Light Mystic",
@@ -15446,7 +15446,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cc/Light_Mystic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Light_Mystic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Light_Mystic"
       },
       {
         "name": "Lighting Technician",
@@ -15459,7 +15459,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b0/Lighting_Technician.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lighting_Technician"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lighting_Technician"
       },
       {
         "name": "Liliane",
@@ -15472,7 +15472,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7d/Liliane.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Liliane"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Liliane"
       },
       {
         "name": "Lir",
@@ -15485,7 +15485,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dd/Lir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lir"
       },
       {
         "name": "Little Angel",
@@ -15498,7 +15498,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/35/Little_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Angel"
       },
       {
         "name": "Little Fox",
@@ -15511,7 +15511,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c2/Little_Fox.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Fox"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Fox"
       },
       {
         "name": "Mandragora",
@@ -15524,7 +15524,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/77/Mandragora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mandragora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mandragora"
       },
       {
         "name": "Mara",
@@ -15537,7 +15537,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/23/Mara.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mara"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mara"
       },
       {
         "name": "Medic",
@@ -15550,7 +15550,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/26/Medic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medic"
       },
       {
         "name": "Mimic",
@@ -15563,7 +15563,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a8/Mimic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mimic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mimic"
       },
       {
         "name": "Mini Muncher",
@@ -15576,7 +15576,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/05/Mini_Muncher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mini_Muncher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mini_Muncher"
       },
       {
         "name": "Moon Rabbit",
@@ -15589,7 +15589,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Moon_Rabbit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Moon_Rabbit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Moon_Rabbit"
       },
       {
         "name": "Morton",
@@ -15602,7 +15602,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/52/Morton.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morton"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morton"
       },
       {
         "name": "Muse",
@@ -15615,7 +15615,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/19/Muse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Muse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Muse"
       },
       {
         "name": "New Girl",
@@ -15628,7 +15628,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b1/New_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/New_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/New_Girl"
       },
       {
         "name": "Oneiros",
@@ -15641,7 +15641,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2e/Oneiros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oneiros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oneiros"
       },
       {
         "name": "Onomatopoeia",
@@ -15654,7 +15654,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1a/Onomatopoeia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Onomatopoeia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Onomatopoeia"
       },
       {
         "name": "Oracle",
@@ -15667,7 +15667,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/17/Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oracle"
       },
       {
         "name": "Ottar",
@@ -15680,7 +15680,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/78/Ottar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ottar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ottar"
       },
       {
         "name": "Paladin",
@@ -15693,7 +15693,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/07/Paladin_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paladin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paladin"
       },
       {
         "name": "Patrol",
@@ -15706,7 +15706,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fd/Patrol.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Patrol"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Patrol"
       },
       {
         "name": "Patroller",
@@ -15719,7 +15719,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7b/Patroller.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Patroller"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Patroller"
       },
       {
         "name": "Pearl",
@@ -15732,7 +15732,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/73/Pearl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pearl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pearl"
       },
       {
         "name": "Pillow Fighter",
@@ -15745,7 +15745,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/be/Pillow_Fighter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pillow_Fighter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pillow_Fighter"
       },
       {
         "name": "Pondering Pixie",
@@ -15758,7 +15758,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fd/Pondering_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pondering_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pondering_Pixie"
       },
       {
         "name": "Princess Choco",
@@ -15771,7 +15771,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/88/Princess_Choco.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess_Choco"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess_Choco"
       },
       {
         "name": "Principality",
@@ -15784,7 +15784,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8b/Principality.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Principality"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Principality"
       },
       {
         "name": "Prost",
@@ -15797,7 +15797,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/25/Prost.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Prost"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Prost"
       },
       {
         "name": "Raikoben",
@@ -15810,7 +15810,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/6b/Raikoben.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Raikoben"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Raikoben"
       },
       {
         "name": "Ramiel",
@@ -15823,7 +15823,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fb/Ramiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ramiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ramiel"
       },
       {
         "name": "Ribbon Girl",
@@ -15836,7 +15836,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cf/Ribbon_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ribbon_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ribbon_Girl"
       },
       {
         "name": "Romance",
@@ -15849,7 +15849,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/ab/Romance.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Romance"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Romance"
       },
       {
         "name": "Saraswati",
@@ -15862,7 +15862,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bd/Saraswati.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saraswati"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saraswati"
       },
       {
         "name": "Scarecrow",
@@ -15875,7 +15875,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/75/Scarecrow.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scarecrow"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scarecrow"
       },
       {
         "name": "Ship's Doctor",
@@ -15888,7 +15888,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b6/Ship%27s_Doctor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ship%27s_Doctor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ship%27s_Doctor"
       },
       {
         "name": "Sleeping Beauty",
@@ -15901,7 +15901,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f2/Sleeping_Beauty.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sleeping_Beauty"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sleeping_Beauty"
       },
       {
         "name": "Sparky",
@@ -15914,7 +15914,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/eb/Sparky.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sparky"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sparky"
       },
       {
         "name": "Stein",
@@ -15927,7 +15927,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/45/Stein.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stein"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stein"
       },
       {
         "name": "Super Soldier",
@@ -15940,7 +15940,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7a/Super_Soldier_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Soldier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Soldier"
       },
       {
         "name": "Support Droid",
@@ -15953,7 +15953,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/49/Support_Droid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Support_Droid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Support_Droid"
       },
       {
         "name": "Susie",
@@ -15966,7 +15966,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5c/Susie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Susie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Susie"
       },
       {
         "name": "Suzu-No-O",
@@ -15979,7 +15979,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/75/Suzu-No-O.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Suzu-No-O"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Suzu-No-O"
       },
       {
         "name": "Tannenbaum Lancer",
@@ -15992,7 +15992,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c9/Tannenbaum_Lancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tannenbaum_Lancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tannenbaum_Lancer"
       },
       {
         "name": "Tavris",
@@ -16005,7 +16005,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a2/Tavris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tavris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tavris"
       },
       {
         "name": "Temple Knight",
@@ -16018,7 +16018,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d6/Temple_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Temple_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Temple_Knight"
       },
       {
         "name": "Thrones",
@@ -16031,7 +16031,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/ca/Thrones.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thrones"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thrones"
       },
       {
         "name": "Time Traveler",
@@ -16044,7 +16044,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f6/Time_Traveler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Time_Traveler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Time_Traveler"
       },
       {
         "name": "Valkyrie Hero",
@@ -16057,7 +16057,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3e/Valkyrie_Hero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Valkyrie_Hero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Valkyrie_Hero"
       },
       {
         "name": "Vocation",
@@ -16070,7 +16070,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1c/Vocation.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vocation"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vocation"
       },
       {
         "name": "Volt",
@@ -16083,7 +16083,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f5/Volt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Volt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Volt"
       },
       {
         "name": "White Mage",
@@ -16096,7 +16096,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e7/White_Mage.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Mage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Mage"
       },
       {
         "name": "Wind-Up Doll",
@@ -16109,7 +16109,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/db/Wind-Up_Doll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wind-Up_Doll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wind-Up_Doll"
       },
       {
         "name": "Yunohana",
@@ -16122,7 +16122,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/de/Yunohana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yunohana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yunohana"
       },
       {
         "name": "Acupuncturist",
@@ -16135,7 +16135,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2a/Acupuncturist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Acupuncturist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Acupuncturist"
       },
       {
         "name": "Aero",
@@ -16152,7 +16152,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ad/Aero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aero"
       },
       {
         "name": "Aladdin",
@@ -16165,7 +16165,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c3/Aladdin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aladdin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aladdin"
       },
       {
         "name": "Alnair",
@@ -16178,7 +16178,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Alnair.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alnair"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alnair"
       },
       {
         "name": "Alpheratz",
@@ -16191,7 +16191,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b1/Alpheratz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alpheratz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alpheratz"
       },
       {
         "name": "Amadeus",
@@ -16208,7 +16208,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f2/Amadeus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amadeus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amadeus"
       },
       {
         "name": "Amber",
@@ -16225,7 +16225,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/01/Amber.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amber"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amber"
       },
       {
         "name": "Amenohoakari",
@@ -16238,7 +16238,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fa/Amenohoakari.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amenohoakari"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amenohoakari"
       },
       {
         "name": "Amethyst",
@@ -16255,7 +16255,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2e/Amethyst.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amethyst"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amethyst"
       },
       {
         "name": "Anahita",
@@ -16268,7 +16268,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/72/Anahita.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anahita"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anahita"
       },
       {
         "name": "Ancile",
@@ -16285,7 +16285,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Ancile.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ancile"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ancile"
       },
       {
         "name": "Aphrodite",
@@ -16298,7 +16298,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c6/Aphrodite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aphrodite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aphrodite"
       },
       {
         "name": "Apollo",
@@ -16315,7 +16315,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/14/Apollo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Apollo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Apollo"
       },
       {
         "name": "Archangel",
@@ -16328,7 +16328,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/40/Archangel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Archangel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Archangel"
       },
       {
         "name": "Arianrhod",
@@ -16341,7 +16341,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/86/Arianrhod.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arianrhod"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arianrhod"
       },
       {
         "name": "Arum",
@@ -16358,7 +16358,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9a/Arum.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arum"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arum"
       },
       {
         "name": "Asclepius",
@@ -16371,7 +16371,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/12/Asclepius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asclepius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asclepius"
       },
       {
         "name": "Ash",
@@ -16384,7 +16384,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b1/Ash.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ash"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ash"
       },
       {
         "name": "Asphodelus",
@@ -16397,7 +16397,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/86/Asphodelus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asphodelus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asphodelus"
       },
       {
         "name": "Astraea",
@@ -16414,7 +16414,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/83/Astraea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astraea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astraea"
       },
       {
         "name": "Athena",
@@ -16431,7 +16431,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/68/Athena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Athena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Athena"
       },
       {
         "name": "Auxo",
@@ -16444,7 +16444,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f5/Auxo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Auxo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Auxo"
       },
       {
         "name": "Backstage Pixie",
@@ -16457,7 +16457,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c1/Backstage_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Backstage_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Backstage_Pixie"
       },
       {
         "name": "Bastia",
@@ -16474,7 +16474,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/77/Bastia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bastia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bastia"
       },
       {
         "name": "Batur",
@@ -16487,7 +16487,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bb/Batur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Batur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Batur"
       },
       {
         "name": "Beer Babe",
@@ -16500,7 +16500,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ea/Beer_Babe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beer_Babe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beer_Babe"
       },
       {
         "name": "Bertina",
@@ -16513,7 +16513,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/65/Bertina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bertina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bertina"
       },
       {
         "name": "Blazing Muspell",
@@ -16530,7 +16530,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/85/Blazing_Muspell_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blazing_Muspell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blazing_Muspell"
       },
       {
         "name": "Blossom Princess",
@@ -16543,7 +16543,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/cc/Blossom_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blossom_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blossom_Princess"
       },
       {
         "name": "Bookmarker",
@@ -16556,7 +16556,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/dd/Bookmarker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bookmarker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bookmarker"
       },
       {
         "name": "Byakuya",
@@ -16569,7 +16569,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/08/Byakuya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Byakuya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Byakuya"
       },
       {
         "name": "Card Collector",
@@ -16586,7 +16586,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/56/Card_Collector.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Card_Collector"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Card_Collector"
       },
       {
         "name": "Castor",
@@ -16599,7 +16599,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3d/Castor_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Castor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Castor"
       },
       {
         "name": "Cat's Cradle",
@@ -16612,7 +16612,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7b/Cat%27s_Cradle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cat%27s_Cradle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cat%27s_Cradle"
       },
       {
         "name": "Celestial Hades",
@@ -16629,7 +16629,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/38/Celestial_Hades_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celestial_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celestial_Hades"
       },
       {
         "name": "Chen Gong",
@@ -16642,7 +16642,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e4/Chen_Gong.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chen_Gong"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chen_Gong"
       },
       {
         "name": "Celara",
@@ -16659,7 +16659,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2b/Celara.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celara"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celara"
       },
       {
         "name": "Chronos",
@@ -16676,7 +16676,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/94/Chronos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chronos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chronos"
       },
       {
         "name": "Cocoa",
@@ -16689,7 +16689,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8d/Cocoa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cocoa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cocoa"
       },
       {
         "name": "Count Up",
@@ -16702,7 +16702,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/50/Count_Up_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Count_Up"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Count_Up"
       },
       {
         "name": "Course Worker",
@@ -16715,7 +16715,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7a/Course_Worker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Course_Worker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Course_Worker"
       },
       {
         "name": "Dinosaur",
@@ -16732,7 +16732,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/89/Dinosaur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dinosaur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dinosaur"
       },
       {
         "name": "Dr. Feelgood",
@@ -16749,7 +16749,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9a/Dr._Feelgood.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dr._Feelgood"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dr._Feelgood"
       },
       {
         "name": "Durga",
@@ -16762,7 +16762,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/73/Durga.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Durga"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Durga"
       },
       {
         "name": "Empress Doll",
@@ -16775,7 +16775,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/17/Empress_Doll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress_Doll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress_Doll"
       },
       {
         "name": "Engineer",
@@ -16788,7 +16788,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d8/Engineer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Engineer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Engineer"
       },
       {
         "name": "Enlil",
@@ -16805,7 +16805,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/81/Enlil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Enlil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Enlil"
       },
       {
         "name": "Enyo",
@@ -16818,7 +16818,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/06/Enyo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Enyo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Enyo"
       },
       {
         "name": "Erin",
@@ -16835,7 +16835,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2d/Erin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Erin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Erin"
       },
       {
         "name": "Eros",
@@ -16848,7 +16848,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7b/Eros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eros"
       },
       {
         "name": "Eunice",
@@ -16865,7 +16865,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/65/Eunice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eunice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eunice"
       },
       {
         "name": "Excalibur",
@@ -16878,7 +16878,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fa/Excalibur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Excalibur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Excalibur"
       },
       {
         "name": "Fel",
@@ -16891,7 +16891,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e1/Fel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fel"
       },
       {
         "name": "Fiona",
@@ -16908,7 +16908,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3c/Fiona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fiona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fiona"
       },
       {
         "name": "Flora",
@@ -16933,7 +16933,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/90/Flora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flora"
       },
       {
         "name": "Fortune Egg",
@@ -16946,7 +16946,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1d/Fortune_Egg.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fortune_Egg"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fortune_Egg"
       },
       {
         "name": "Fruit Candle",
@@ -16959,7 +16959,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c3/Fruit_Candle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fruit_Candle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fruit_Candle"
       },
       {
         "name": "Gabriel",
@@ -16972,7 +16972,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/da/Gabriel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gabriel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gabriel"
       },
       {
         "name": "Gaia",
@@ -16985,7 +16985,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/80/Gaia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gaia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gaia"
       },
       {
         "name": "Gamigin",
@@ -16998,7 +16998,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/19/Gamigin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gamigin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gamigin"
       },
       {
         "name": "Ganache",
@@ -17011,7 +17011,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9d/Ganache.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ganache"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ganache"
       },
       {
         "name": "Gem Christmas",
@@ -17024,7 +17024,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/89/Gem_Christmas_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gem_Christmas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gem_Christmas"
       },
       {
         "name": "Gem Noir",
@@ -17041,7 +17041,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/65/Gem_Noir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gem_Noir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gem_Noir"
       },
       {
         "name": "Gem Stolas",
@@ -17054,7 +17054,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f4/Gem_Stolas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gem_Stolas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gem_Stolas"
       },
       {
         "name": "Golgoroth",
@@ -17067,7 +17067,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/61/Golgoroth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Golgoroth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Golgoroth"
       },
       {
         "name": "Harariel",
@@ -17080,7 +17080,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4a/Harariel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Harariel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Harariel"
       },
       {
         "name": "Heaven's Gate",
@@ -17097,7 +17097,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bc/Heaven%27s_Gate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Heaven%27s_Gate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Heaven%27s_Gate"
       },
       {
         "name": "High Elf",
@@ -17110,7 +17110,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4f/High_Elf.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/High_Elf"
+        "link": "http://valkyriecrusade.fandom.com/wiki/High_Elf"
       },
       {
         "name": "High Priest",
@@ -17123,7 +17123,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/ab/High_Priest.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/High_Priest"
+        "link": "http://valkyriecrusade.fandom.com/wiki/High_Priest"
       },
       {
         "name": "Hina",
@@ -17136,7 +17136,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/83/Hina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hina"
       },
       {
         "name": "Hresvelgr",
@@ -17149,7 +17149,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b0/Hresvelgr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hresvelgr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hresvelgr"
       },
       {
         "name": "Iarn",
@@ -17162,7 +17162,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2c/Iarn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Iarn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Iarn"
       },
       {
         "name": "Iris",
@@ -17175,7 +17175,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5c/Iris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Iris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Iris"
       },
       {
         "name": "Iroha",
@@ -17188,7 +17188,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/bf/Iroha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Iroha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Iroha"
       },
       {
         "name": "Ishtar",
@@ -17201,7 +17201,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/04/Ishtar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ishtar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ishtar"
       },
       {
         "name": "Jodie",
@@ -17214,7 +17214,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1d/Jodie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jodie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jodie"
       },
       {
         "name": "Jodie Explorer",
@@ -17227,7 +17227,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e4/Jodie_Explorer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jodie_Explorer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jodie_Explorer"
       },
       {
         "name": "Kathleen",
@@ -17240,7 +17240,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/eb/Kathleen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kathleen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kathleen"
       },
       {
         "name": "Kiki",
@@ -17257,7 +17257,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4a/Kiki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kiki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kiki"
       },
       {
         "name": "Kikurihime",
@@ -17274,7 +17274,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/66/Kikurihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kikurihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kikurihime"
       },
       {
         "name": "Komainu Twins",
@@ -17287,7 +17287,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c6/Komainu_Twins.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Komainu_Twins"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Komainu_Twins"
       },
       {
         "name": "Konohanasakuya",
@@ -17300,7 +17300,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dd/Konohanasakuya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Konohanasakuya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Konohanasakuya"
       },
       {
         "name": "Lakshmi",
@@ -17313,7 +17313,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bc/Lakshmi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lakshmi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lakshmi"
       },
       {
         "name": "Layla",
@@ -17326,7 +17326,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c8/Layla.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Layla"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Layla"
       },
       {
         "name": "Legend Gambler",
@@ -17339,7 +17339,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/31/Legend_Gambler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Legend_Gambler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Legend_Gambler"
       },
       {
         "name": "Li Linfu",
@@ -17356,7 +17356,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8b/Li_Linfu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Li_Linfu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Li_Linfu"
       },
       {
         "name": "Light Fairy",
@@ -17369,7 +17369,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/61/Light_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Light_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Light_Fairy"
       },
       {
         "name": "Lightning Volt",
@@ -17382,7 +17382,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/56/Lightning_Volt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lightning_Volt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lightning_Volt"
       },
       {
         "name": "Lil' New Year",
@@ -17395,7 +17395,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3e/Lil%27_New_Year.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lil%27_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lil%27_New_Year"
       },
       {
         "name": "Lirissa",
@@ -17416,7 +17416,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1a/Lirissa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lirissa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lirissa"
       },
       {
         "name": "Lock Heart",
@@ -17433,7 +17433,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4e/Lock_Heart.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lock_Heart"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lock_Heart"
       },
       {
         "name": "Luna",
@@ -17446,7 +17446,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/13/Luna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Luna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Luna"
       },
       {
         "name": "Macaron",
@@ -17459,7 +17459,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e4/Macaron.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Macaron"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Macaron"
       },
       {
         "name": "Manticore",
@@ -17476,7 +17476,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/03/Manticore.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Manticore"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Manticore"
       },
       {
         "name": "Metatron",
@@ -17493,7 +17493,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7f/Metatron.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Metatron"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Metatron"
       },
       {
         "name": "Metis",
@@ -17506,7 +17506,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b7/Metis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Metis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Metis"
       },
       {
         "name": "Mia",
@@ -17519,7 +17519,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/45/Mia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mia"
       },
       {
         "name": "Michael",
@@ -17532,7 +17532,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f3/Michael.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Michael"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Michael"
       },
       {
         "name": "Mithras",
@@ -17545,7 +17545,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/82/Mithras.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mithras"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mithras"
       },
       {
         "name": "Morphium",
@@ -17562,7 +17562,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/87/Morphium.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morphium"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morphium"
       },
       {
         "name": "Morphium New year",
@@ -17579,7 +17579,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e1/Morphium_New_Year_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morphium_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morphium_New_Year"
       },
       {
         "name": "Morta",
@@ -17592,7 +17592,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/20/Morta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morta"
       },
       {
         "name": "Multiple Eye",
@@ -17605,7 +17605,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e1/Multiple_Eye.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Multiple_Eye"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Multiple_Eye"
       },
       {
         "name": "Muspell",
@@ -17622,7 +17622,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f5/Muspell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Muspell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Muspell"
       },
       {
         "name": "Mythic Knight",
@@ -17635,7 +17635,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4a/Mythic_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mythic_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mythic_Knight"
       },
       {
         "name": "Nausicaa",
@@ -17652,7 +17652,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/53/Nausicaa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nausicaa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nausicaa"
       },
       {
         "name": "Nicola",
@@ -17665,7 +17665,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e6/Nicola.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nicola"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nicola"
       },
       {
         "name": "Nike",
@@ -17678,7 +17678,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c5/Nike.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nike"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nike"
       },
       {
         "name": "Niumri",
@@ -17695,7 +17695,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/ae/Niumri.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Niumri"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Niumri"
       },
       {
         "name": "Noah",
@@ -17708,7 +17708,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/dd/Noah.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Noah"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Noah"
       },
       {
         "name": "Noel",
@@ -17721,7 +17721,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b3/Noel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Noel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Noel"
       },
       {
         "name": "Nymph",
@@ -17734,7 +17734,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/62/Nymph.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nymph"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nymph"
       },
       {
         "name": "Olav",
@@ -17747,7 +17747,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0c/Olav.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Olav"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Olav"
       },
       {
         "name": "One-Eyed Dragon",
@@ -17760,7 +17760,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/79/One-Eyed_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/One-Eyed_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/One-Eyed_Dragon"
       },
       {
         "name": "Oruro",
@@ -17773,7 +17773,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/37/Oruro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oruro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oruro"
       },
       {
         "name": "Pan",
@@ -17786,7 +17786,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/ca/Pan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pan"
       },
       {
         "name": "Parentalia",
@@ -17799,7 +17799,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ef/Parentalia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Parentalia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Parentalia"
       },
       {
         "name": "Parfait",
@@ -17812,7 +17812,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/88/Parfait.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Parfait"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Parfait"
       },
       {
         "name": "Parvati",
@@ -17829,7 +17829,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bc/Parvati.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Parvati"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Parvati"
       },
       {
         "name": "Pele",
@@ -17846,7 +17846,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5d/Pele.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pele"
       },
       {
         "name": "Penemue",
@@ -17863,7 +17863,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/77/Penemue.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Penemue"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Penemue"
       },
       {
         "name": "Pincho",
@@ -17880,7 +17880,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8a/Pincho.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pincho"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pincho"
       },
       {
         "name": "Ping",
@@ -17897,7 +17897,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/12/Ping.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ping"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ping"
       },
       {
         "name": "Pirates Gun",
@@ -17910,7 +17910,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/80/Pirates_Gun.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pirates_Gun"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pirates_Gun"
       },
       {
         "name": "Polaris",
@@ -17927,7 +17927,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a2/Polaris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Polaris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Polaris"
       },
       {
         "name": "Pudding",
@@ -17944,7 +17944,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/23/Pudding.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pudding"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pudding"
       },
       {
         "name": "Qilin",
@@ -17961,7 +17961,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/9b/Qilin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Qilin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Qilin"
       },
       {
         "name": "Quetzalcoatl",
@@ -17974,7 +17974,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/61/Quetzalcoatl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Quetzalcoatl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Quetzalcoatl"
       },
       {
         "name": "Quraly",
@@ -17991,7 +17991,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ae/Quraly.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Quraly"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Quraly"
       },
       {
         "name": "Raphael",
@@ -18008,7 +18008,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5a/Raphael.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Raphael"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Raphael"
       },
       {
         "name": "Rise & Shine",
@@ -18021,7 +18021,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/88/Rise_%26_Shine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rise_%26_Shine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rise_%26_Shine"
       },
       {
         "name": "Roseria",
@@ -18034,7 +18034,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/49/Roseria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roseria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roseria"
       },
       {
         "name": "Rosetta",
@@ -18051,7 +18051,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/af/Rosetta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rosetta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rosetta"
       },
       {
         "name": "Ruler Girl",
@@ -18068,7 +18068,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b6/Ruler_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ruler_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ruler_Girl"
       },
       {
         "name": "Sacrifice",
@@ -18081,7 +18081,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/18/Sacrifice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacrifice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacrifice"
       },
       {
         "name": "Saint",
@@ -18098,7 +18098,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bc/Saint.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saint"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saint"
       },
       {
         "name": "Santa's Apprentice",
@@ -18111,7 +18111,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/94/Santa%27s_Apprentice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santa%27s_Apprentice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santa%27s_Apprentice"
       },
       {
         "name": "Sea Princess",
@@ -18124,7 +18124,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ef/Sea_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sea_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sea_Princess"
       },
       {
         "name": "Slipper Spirit",
@@ -18137,7 +18137,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f0/Slipper_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Slipper_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Slipper_Spirit"
       },
       {
         "name": "Smokey",
@@ -18150,7 +18150,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b2/Smokey.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Smokey"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Smokey"
       },
       {
         "name": "Spenta Mainyu",
@@ -18163,7 +18163,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e7/Spenta_Mainyu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spenta_Mainyu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spenta_Mainyu"
       },
       {
         "name": "Star Shower",
@@ -18180,7 +18180,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d9/Star_Shower.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Shower"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Shower"
       },
       {
         "name": "Stardust",
@@ -18197,7 +18197,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/65/Stardust.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stardust"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stardust"
       },
       {
         "name": "Super Chimry (Light)",
@@ -18210,7 +18210,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/40/Super_Chimry_%28Light%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Chimry_(Light)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Chimry_(Light)"
       },
       {
         "name": "Talisman",
@@ -18227,7 +18227,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/99/Talisman.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Talisman"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Talisman"
       },
       {
         "name": "Tama-No-Oya",
@@ -18240,7 +18240,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6b/Tama-No-Oya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tama-No-Oya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tama-No-Oya"
       },
       {
         "name": "Teatime",
@@ -18257,7 +18257,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a9/Teatime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teatime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teatime"
       },
       {
         "name": "Teiaiel",
@@ -18270,7 +18270,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9f/Teiaiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teiaiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teiaiel"
       },
       {
         "name": "Tensen Nyannyan",
@@ -18283,7 +18283,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2b/Tensen_Nyannyan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tensen_Nyannyan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tensen_Nyannyan"
       },
       {
         "name": "Teresa",
@@ -18300,7 +18300,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e8/Teresa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teresa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teresa"
       },
       {
         "name": "Tetea",
@@ -18313,7 +18313,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ed/Tetea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tetea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tetea"
       },
       {
         "name": "Thelxinoe",
@@ -18326,7 +18326,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/06/Thelxinoe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thelxinoe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thelxinoe"
       },
       {
         "name": "Thor",
@@ -18343,7 +18343,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0b/Thor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thor"
       },
       {
         "name": "Titania",
@@ -18356,7 +18356,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/24/Titania.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Titania"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Titania"
       },
       {
         "name": "Uriel",
@@ -18373,7 +18373,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a7/Uriel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Uriel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Uriel"
       },
       {
         "name": "Ursula",
@@ -18386,7 +18386,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a4/Ursula.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ursula"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ursula"
       },
       {
         "name": "Ushas",
@@ -18399,7 +18399,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/04/Ushas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ushas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ushas"
       },
       {
         "name": "Vaccine",
@@ -18412,7 +18412,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2e/Vaccine_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vaccine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vaccine"
       },
       {
         "name": "Venus",
@@ -18425,7 +18425,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dc/Venus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Venus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Venus"
       },
       {
         "name": "Verethragna",
@@ -18438,7 +18438,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/45/Verethragna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Verethragna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Verethragna"
       },
       {
         "name": "Vesti",
@@ -18455,7 +18455,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1d/Vesti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vesti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vesti"
       },
       {
         "name": "Vidar",
@@ -18472,7 +18472,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/af/Vidar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vidar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vidar"
       },
       {
         "name": "Virtual Vandal",
@@ -18485,7 +18485,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a7/Virtual_Vandal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virtual_Vandal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virtual_Vandal"
       },
       {
         "name": "Vitruvius",
@@ -18502,7 +18502,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0a/Vitruvius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vitruvius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vitruvius"
       },
       {
         "name": "Vulthoom",
@@ -18519,7 +18519,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/66/Vulthoom.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vulthoom"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vulthoom"
       },
       {
         "name": "Wandering Sanzo",
@@ -18532,7 +18532,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/60/Wandering_Sanzo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wandering_Sanzo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wandering_Sanzo"
       },
       {
         "name": "Warm Milk",
@@ -18549,7 +18549,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e9/Warm_Milk.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Warm_Milk"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Warm_Milk"
       },
       {
         "name": "White Tiger",
@@ -18562,7 +18562,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5d/White_Tiger.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Tiger"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Tiger"
       },
       {
         "name": "Will-o'-the-Wisp",
@@ -18575,7 +18575,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/31/Will-o%27-the-Wisp.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Will-o%27-the-Wisp"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Will-o%27-the-Wisp"
       },
       {
         "name": "Windsurfer",
@@ -18588,7 +18588,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/52/Windsurfer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Windsurfer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Windsurfer"
       },
       {
         "name": "Xochiquetzal",
@@ -18601,7 +18601,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/18/Xochiquetzal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Xochiquetzal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Xochiquetzal"
       },
       {
         "name": "Zofia",
@@ -18618,7 +18618,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f9/Zofia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zofia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zofia"
       },
       {
         "name": "Ababinili",
@@ -18635,7 +18635,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e4/Ababinili.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ababinili"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ababinili"
       },
       {
         "name": "Aegis",
@@ -18652,7 +18652,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e5/Aegis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aegis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aegis"
       },
       {
         "name": "Agrippa",
@@ -18669,7 +18669,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/96/Agrippa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Agrippa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Agrippa"
       },
       {
         "name": "Ahes",
@@ -18686,7 +18686,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1f/Ahes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ahes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ahes"
       },
       {
         "name": "Al-mi'raj",
@@ -18703,7 +18703,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fa/Al-mi%27raj.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Al-mi%27raj"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Al-mi%27raj"
       },
       {
         "name": "Alabaster Hina",
@@ -18720,7 +18720,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b8/Alabaster_Hina_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alabaster_Hina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alabaster_Hina"
       },
       {
         "name": "Alarm Sheep",
@@ -18737,7 +18737,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/02/Alarm_Sheep.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alarm_Sheep"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alarm_Sheep"
       },
       {
         "name": "Alien Hu Ji",
@@ -18754,7 +18754,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3b/Alien_Hu_Ji.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Hu_Ji"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Hu_Ji"
       },
       {
         "name": "Alien Musse",
@@ -18771,7 +18771,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d6/Alien_Musse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Musse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Musse"
       },
       {
         "name": "Amakoyane",
@@ -18788,7 +18788,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/05/Amakoyane.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amakoyane"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amakoyane"
       },
       {
         "name": "Amakoyane New Year",
@@ -18805,7 +18805,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/ba/Amakoyane_New_Year_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amakoyane_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amakoyane_New_Year"
       },
       {
         "name": "Android Warrior",
@@ -18822,7 +18822,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1e/Android_Warrior.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Android_Warrior"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Android_Warrior"
       },
       {
         "name": "Ann",
@@ -18839,7 +18839,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/30/Ann.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ann"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ann"
       },
       {
         "name": "Arare Princess",
@@ -18860,7 +18860,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/65/Arare_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arare_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arare_Princess"
       },
       {
         "name": "Argent",
@@ -18877,7 +18877,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7d/Argent.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Argent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Argent"
       },
       {
         "name": "Assault Angel",
@@ -18894,7 +18894,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2b/Assault_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Assault_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Assault_Angel"
       },
       {
         "name": "Astral Christmas",
@@ -18907,7 +18907,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/41/Astral_Christmas_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astral_Christmas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astral_Christmas"
       },
       {
         "name": "Astral Noir",
@@ -18924,7 +18924,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/63/Astral_Noir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astral_Noir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astral_Noir"
       },
       {
         "name": "Azoth",
@@ -18941,7 +18941,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c7/Azoth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Azoth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Azoth"
       },
       {
         "name": "Bahamut",
@@ -18958,7 +18958,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/21/Bahamut.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bahamut"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bahamut"
       },
       {
         "name": "Balero",
@@ -18975,7 +18975,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/32/Balero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balero"
       },
       {
         "name": "Ballroom Hades",
@@ -18992,7 +18992,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1f/Ballroom_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ballroom_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ballroom_Hades"
       },
       {
         "name": "Bambi",
@@ -19009,7 +19009,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2d/Bambi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bambi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bambi"
       },
       {
         "name": "Bamboo Cannon",
@@ -19026,7 +19026,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0f/Bamboo_Cannon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bamboo_Cannon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bamboo_Cannon"
       },
       {
         "name": "Bell",
@@ -19043,7 +19043,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/6e/Bell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bell"
       },
       {
         "name": "Blazing Ababinili",
@@ -19060,7 +19060,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/cf/Blazing_Ababinili_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blazing_Ababinili"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blazing_Ababinili"
       },
       {
         "name": "Blazing Tupsimati",
@@ -19077,7 +19077,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b7/Blazing_Tupsimati_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blazing_Tupsimati"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blazing_Tupsimati"
       },
       {
         "name": "Blitzen",
@@ -19094,7 +19094,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/00/Blitzen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blitzen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blitzen"
       },
       {
         "name": "Blue Star Treker",
@@ -19111,7 +19111,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/30/Blue_Star_Treker_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blue_Star_Treker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blue_Star_Treker"
       },
       {
         "name": "Bomby",
@@ -19132,7 +19132,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/96/Bomby.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bomby"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bomby"
       },
       {
         "name": "Bonfire Babe",
@@ -19149,7 +19149,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f1/Bonfire_Babe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bonfire_Babe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bonfire_Babe"
       },
       {
         "name": "Bridal Argent",
@@ -19166,7 +19166,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Bridal_Argent_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bridal_Argent"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bridal_Argent"
       },
       {
         "name": "Cagliostro",
@@ -19183,7 +19183,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1f/Cagliostro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cagliostro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cagliostro"
       },
       {
         "name": "Calligrapher",
@@ -19200,7 +19200,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/17/Calligrapher.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Calligrapher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Calligrapher"
       },
       {
         "name": "Candy Champion",
@@ -19213,7 +19213,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0e/Candy_Champion_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Candy_Champion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Candy_Champion"
       },
       {
         "name": "Celestial Alchemist",
@@ -19226,7 +19226,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d8/Celestial_Alchemist_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celestial_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celestial_Alchemist"
       },
       {
         "name": "Charlotte",
@@ -19243,7 +19243,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f3/Charlotte.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Charlotte"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Charlotte"
       },
       {
         "name": "Cheerful Pixie",
@@ -19260,7 +19260,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fe/Cheerful_Pixie_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cheerful_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cheerful_Pixie"
       },
       {
         "name": "Chocolate Candy",
@@ -19277,7 +19277,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/55/Chocolate_Candy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocolate_Candy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocolate_Candy"
       },
       {
         "name": "Christos",
@@ -19294,7 +19294,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/81/Christos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Christos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Christos"
       },
       {
         "name": "Clay Master",
@@ -19311,7 +19311,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/78/Clay_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Clay_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Clay_Master"
       },
       {
         "name": "Clover",
@@ -19328,7 +19328,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c4/Clover.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Clover"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Clover"
       },
       {
         "name": "Confetti",
@@ -19345,7 +19345,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/72/Confetti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Confetti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Confetti"
       },
       {
         "name": "Cucca",
@@ -19362,7 +19362,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/68/Cucca.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cucca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cucca"
       },
       {
         "name": "Cucco",
@@ -19379,7 +19379,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/51/Cucco.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cucco"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cucco"
       },
       {
         "name": "Dark Luca",
@@ -19396,7 +19396,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Dark_Luca.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Luca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Luca"
       },
       {
         "name": "Divine Panacea",
@@ -19413,7 +19413,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f2/Divine_Panacea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Panacea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Panacea"
       },
       {
         "name": "Divine Poseidon",
@@ -19426,7 +19426,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f2/Divine_Poseidon_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Poseidon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Poseidon"
       },
       {
         "name": "Dream Pillow",
@@ -19443,7 +19443,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/39/Dream_Pillow.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dream_Pillow"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dream_Pillow"
       },
       {
         "name": "Dreamwalker",
@@ -19460,7 +19460,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8e/Dreamwalker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dreamwalker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dreamwalker"
       },
       {
         "name": "Dress Hunter",
@@ -19477,7 +19477,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bd/Dress_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dress_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dress_Hunter"
       },
       {
         "name": "Drum Major",
@@ -19494,7 +19494,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d7/Drum_Major.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Drum_Major"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Drum_Major"
       },
       {
         "name": "Ebisu",
@@ -19511,7 +19511,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/77/Ebisu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ebisu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ebisu"
       },
       {
         "name": "Ecrire",
@@ -19528,7 +19528,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0f/Ecrire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ecrire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ecrire"
       },
       {
         "name": "Empress Cynthia",
@@ -19541,7 +19541,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/de/Empress_Cynthia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress_Cynthia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress_Cynthia"
       },
       {
         "name": "Fairy Princess",
@@ -19558,7 +19558,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/01/Fairy_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fairy_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fairy_Princess"
       },
       {
         "name": "Fastener",
@@ -19575,7 +19575,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/03/Fastener.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fastener"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fastener"
       },
       {
         "name": "Felt",
@@ -19596,7 +19596,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b0/Felt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Felt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Felt"
       },
       {
         "name": "Flapjack",
@@ -19613,7 +19613,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f8/Flapjack.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flapjack"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flapjack"
       },
       {
         "name": "Float",
@@ -19630,7 +19630,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c8/Float.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Float"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Float"
       },
       {
         "name": "Flower Queen",
@@ -19647,7 +19647,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7c/Flower_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flower_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flower_Queen"
       },
       {
         "name": "Frostbite",
@@ -19664,7 +19664,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ee/Frostbite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Frostbite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Frostbite"
       },
       {
         "name": "Furyu",
@@ -19681,7 +19681,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6f/Furyu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furyu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furyu"
       },
       {
         "name": "Fusehime",
@@ -19698,7 +19698,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/67/Fusehime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fusehime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fusehime"
       },
       {
         "name": "Futodama",
@@ -19715,7 +19715,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/30/Futodama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Futodama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Futodama"
       },
       {
         "name": "Futodama New Year",
@@ -19732,7 +19732,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/90/Futodama_New_Year_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Futodama_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Futodama_New_Year"
       },
       {
         "name": "Fytir",
@@ -19749,7 +19749,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/76/Fytir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fytir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fytir"
       },
       {
         "name": "Ghostly Schwartz",
@@ -19770,7 +19770,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b5/Ghostly_Schwartz_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghostly_Schwartz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghostly_Schwartz"
       },
       {
         "name": "Goddess Cynthia",
@@ -19787,7 +19787,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/ac/Goddess_Cynthia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Goddess_Cynthia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Goddess_Cynthia"
       },
       {
         "name": "Gondolier",
@@ -19804,7 +19804,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/aa/Gondolier.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gondolier"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gondolier"
       },
       {
         "name": "Graffiti Artist",
@@ -19821,7 +19821,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1f/Graffiti_Artist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Graffiti_Artist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Graffiti_Artist"
       },
       {
         "name": "Harmonia",
@@ -19838,7 +19838,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/84/Harmonia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Harmonia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Harmonia"
       },
       {
         "name": "Herb Christmas",
@@ -19851,7 +19851,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/aa/Herb_Christmas_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Herb_Christmas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Herb_Christmas"
       },
       {
         "name": "Herb Noir",
@@ -19868,7 +19868,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/ba/Herb_Noir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Herb_Noir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Herb_Noir"
       },
       {
         "name": "Hiraga",
@@ -19889,7 +19889,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/58/Hiraga.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hiraga"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hiraga"
       },
       {
         "name": "Hrungnir",
@@ -19906,7 +19906,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d4/Hrungnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hrungnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hrungnir"
       },
       {
         "name": "Huang Long",
@@ -19923,7 +19923,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/91/Huang_Long.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Huang_Long"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Huang_Long"
       },
       {
         "name": "Hvare",
@@ -19940,7 +19940,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/83/Hvare.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hvare"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hvare"
       },
       {
         "name": "Hygieia",
@@ -19957,7 +19957,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9a/Hygieia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hygieia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hygieia"
       },
       {
         "name": "Hyper Alchemist",
@@ -19974,7 +19974,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2b/Hyper_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Alchemist"
       },
       {
         "name": "Hyper Chimry (Light)",
@@ -19987,7 +19987,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/97/Hyper_Chimry_%28Light%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Chimry_(Light)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Chimry_(Light)"
       },
       {
         "name": "Hypnotist",
@@ -20008,7 +20008,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e6/Hypnotist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hypnotist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hypnotist"
       },
       {
         "name": "Icarus",
@@ -20025,7 +20025,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/45/Icarus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Icarus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Icarus"
       },
       {
         "name": "Idun",
@@ -20042,7 +20042,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0c/Idun.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Idun"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Idun"
       },
       {
         "name": "Impuesto",
@@ -20059,7 +20059,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/51/Impuesto.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Impuesto"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Impuesto"
       },
       {
         "name": "Jeanne D'Arc",
@@ -20076,7 +20076,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b5/Jeanne_D%27Arc.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jeanne_D%27Arc"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jeanne_D%27Arc"
       },
       {
         "name": "Jelly Jelly",
@@ -20093,7 +20093,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b6/Jelly_Jelly.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jelly_Jelly"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jelly_Jelly"
       },
       {
         "name": "Juno",
@@ -20110,7 +20110,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4a/Juno.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Juno"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Juno"
       },
       {
         "name": "Kabukimono",
@@ -20127,7 +20127,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b3/Kabukimono.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kabukimono"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kabukimono"
       },
       {
         "name": "Kanon",
@@ -20148,7 +20148,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/71/Kanon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kanon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kanon"
       },
       {
         "name": "Key Master",
@@ -20165,7 +20165,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0e/Key_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Key_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Key_Master"
       },
       {
         "name": "Kikimora",
@@ -20182,7 +20182,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ea/Kikimora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kikimora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kikimora"
       },
       {
         "name": "Kitty Kat",
@@ -20199,7 +20199,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/36/Kitty_Kat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kitty_Kat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kitty_Kat"
       },
       {
         "name": "Krazy Kitty Kat",
@@ -20216,7 +20216,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/19/Krazy_Kitty_Kat_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Krazy_Kitty_Kat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Krazy_Kitty_Kat"
       },
       {
         "name": "Kukunochi",
@@ -20233,7 +20233,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/64/Kukunochi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kukunochi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kukunochi"
       },
       {
         "name": "Lancer Alpheratz",
@@ -20250,7 +20250,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/96/Lancer_Alpheratz_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lancer_Alpheratz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lancer_Alpheratz"
       },
       {
         "name": "Last Army",
@@ -20267,7 +20267,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e9/Last_Army.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Last_Army"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Last_Army"
       },
       {
         "name": "Last Boss Zero",
@@ -20280,7 +20280,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/70/Last_Boss_Zero_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Last_Boss_Zero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Last_Boss_Zero"
       },
       {
         "name": "Le Mille",
@@ -20297,7 +20297,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0a/Le_Mille.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Le_Mille"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Le_Mille"
       },
       {
         "name": "Leader Musette",
@@ -20314,7 +20314,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4e/Leader_Musette_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leader_Musette"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leader_Musette"
       },
       {
         "name": "Leader Zero",
@@ -20331,7 +20331,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/63/Leader_Zero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leader_Zero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leader_Zero"
       },
       {
         "name": "Leiria",
@@ -20352,7 +20352,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4d/Leiria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leiria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leiria"
       },
       {
         "name": "Liber",
@@ -20369,7 +20369,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/05/Liber.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Liber"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Liber"
       },
       {
         "name": "Light Luca",
@@ -20386,7 +20386,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/88/Light_Luca_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Light_Luca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Light_Luca"
       },
       {
         "name": "Lily & Mary",
@@ -20403,7 +20403,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/20/Lily_%26_Mary.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lily_%26_Mary"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lily_%26_Mary"
       },
       {
         "name": "Lion Dancer",
@@ -20420,7 +20420,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/37/Lion_Dancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lion_Dancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lion_Dancer"
       },
       {
         "name": "Liscia",
@@ -20437,7 +20437,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a1/Liscia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Liscia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Liscia"
       },
       {
         "name": "Lonsday",
@@ -20454,7 +20454,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e5/Lonsday.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lonsday"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lonsday"
       },
       {
         "name": "Lucia",
@@ -20471,7 +20471,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/34/Lucia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucia"
       },
       {
         "name": "Lugh",
@@ -20488,7 +20488,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/74/Lugh.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lugh"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lugh"
       },
       {
         "name": "Lulu",
@@ -20505,7 +20505,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1f/Lulu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lulu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lulu"
       },
       {
         "name": "Lunar Master",
@@ -20522,7 +20522,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/81/Lunar_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lunar_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lunar_Master"
       },
       {
         "name": "Lusty Fortuna",
@@ -20539,7 +20539,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/11/Lusty_Fortuna_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lusty_Fortuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lusty_Fortuna"
       },
       {
         "name": "Mabel",
@@ -20556,7 +20556,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f0/Mabel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mabel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mabel"
       },
       {
         "name": "Machinist",
@@ -20573,7 +20573,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e0/Machinist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Machinist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Machinist"
       },
       {
         "name": "Mastia",
@@ -20590,7 +20590,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/79/Mastia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mastia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mastia"
       },
       {
         "name": "Mature Hina",
@@ -20607,7 +20607,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7b/Mature_Hina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mature_Hina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mature_Hina"
       },
       {
         "name": "Melodica",
@@ -20624,7 +20624,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/cf/Melodica.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melodica"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melodica"
       },
       {
         "name": "Melon Soda",
@@ -20641,7 +20641,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/58/Melon_Soda.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melon_Soda"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melon_Soda"
       },
       {
         "name": "Merry Magician",
@@ -20658,7 +20658,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/39/Merry_Magician.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Merry_Magician"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Merry_Magician"
       },
       {
         "name": "Midas",
@@ -20675,7 +20675,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d8/Midas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Midas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Midas"
       },
       {
         "name": "Mikoterasu",
@@ -20692,7 +20692,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c9/Mikoterasu_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mikoterasu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mikoterasu"
       },
       {
         "name": "Miss Lunar New Year",
@@ -20709,7 +20709,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8a/Miss_Lunar_New_Year.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Miss_Lunar_New_Year"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Miss_Lunar_New_Year"
       },
       {
         "name": "Mjolnir",
@@ -20726,7 +20726,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/25/Mjolnir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mjolnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mjolnir"
       },
       {
         "name": "Mochitsuki",
@@ -20743,7 +20743,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1e/Mochitsuki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mochitsuki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mochitsuki"
       },
       {
         "name": "Musette",
@@ -20760,7 +20760,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f2/Musette.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Musette"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Musette"
       },
       {
         "name": "Mushroom Phantom",
@@ -20777,7 +20777,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Mushroom_Phantom.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mushroom_Phantom"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mushroom_Phantom"
       },
       {
         "name": "Myria",
@@ -20794,7 +20794,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/15/Myria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Myria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Myria"
       },
       {
         "name": "Nadeshiko",
@@ -20815,7 +20815,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8a/Nadeshiko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nadeshiko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nadeshiko"
       },
       {
         "name": "Niagara",
@@ -20836,7 +20836,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e6/Niagara.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Niagara"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Niagara"
       },
       {
         "name": "Pageant Alchemist",
@@ -20853,7 +20853,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d0/Pageant_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pageant_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pageant_Alchemist"
       },
       {
         "name": "Painter",
@@ -20870,7 +20870,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/24/Painter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Painter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Painter"
       },
       {
         "name": "Persephone",
@@ -20887,7 +20887,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b2/Persephone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Persephone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Persephone"
       },
       {
         "name": "Philippa",
@@ -20904,7 +20904,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9b/Philippa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Philippa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Philippa"
       },
       {
         "name": "Pianissimo",
@@ -20921,7 +20921,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/47/Pianissimo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pianissimo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pianissimo"
       },
       {
         "name": "Pole Position",
@@ -20938,7 +20938,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/53/Pole_Position.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pole_Position"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pole_Position"
       },
       {
         "name": "Premium Prize",
@@ -20955,7 +20955,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f2/Premium_Prize.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Premium_Prize"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Premium_Prize"
       },
       {
         "name": "Quebec",
@@ -20976,7 +20976,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/06/Quebec.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Quebec"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Quebec"
       },
       {
         "name": "Queen Arthur",
@@ -20993,7 +20993,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/fd/Queen_Arthur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Arthur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Arthur"
       },
       {
         "name": "Queen Poseidon",
@@ -21010,7 +21010,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1e/Queen_Poseidon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Poseidon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Poseidon"
       },
       {
         "name": "Radiant Pixie",
@@ -21027,7 +21027,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a9/Radiant_Pixie_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Radiant_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Radiant_Pixie"
       },
       {
         "name": "Rampage Princess",
@@ -21044,7 +21044,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c1/Rampage_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rampage_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rampage_Princess"
       },
       {
         "name": "Rapier Master",
@@ -21057,7 +21057,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/82/Rapier_Master_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rapier_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rapier_Master"
       },
       {
         "name": "Rapier Princess",
@@ -21074,7 +21074,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/28/Rapier_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rapier_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rapier_Princess"
       },
       {
         "name": "Red Wolf Skoll",
@@ -21087,7 +21087,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/99/Red_Wolf_Skoll_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Wolf_Skoll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Wolf_Skoll"
       },
       {
         "name": "Rikayu",
@@ -21104,7 +21104,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8c/Rikayu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rikayu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rikayu"
       },
       {
         "name": "Sacred Amaterasu",
@@ -21125,7 +21125,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/71/Sacred_Amaterasu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacred_Amaterasu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacred_Amaterasu"
       },
       {
         "name": "Saffron",
@@ -21142,7 +21142,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8c/Saffron.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saffron"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saffron"
       },
       {
         "name": "Salomonis",
@@ -21159,7 +21159,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/24/Salomonis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Salomonis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Salomonis"
       },
       {
         "name": "Sanzo",
@@ -21176,7 +21176,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d9/Sanzo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sanzo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sanzo"
       },
       {
         "name": "Secret Toshigami",
@@ -21189,7 +21189,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Secret_Toshigami_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Secret_Toshigami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Secret_Toshigami"
       },
       {
         "name": "Sherbert",
@@ -21210,7 +21210,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8e/Sherbert.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sherbert"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sherbert"
       },
       {
         "name": "Shingetsu",
@@ -21227,7 +21227,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c7/Shingetsu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shingetsu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shingetsu"
       },
       {
         "name": "Shining Pixie",
@@ -21244,7 +21244,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/79/Shining_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shining_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shining_Pixie"
       },
       {
         "name": "Shirley",
@@ -21261,7 +21261,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/e9/Shirley.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shirley"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shirley"
       },
       {
         "name": "Shiroyagi",
@@ -21278,7 +21278,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6a/Shiroyagi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shiroyagi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shiroyagi"
       },
       {
         "name": "Shutter Girl",
@@ -21295,7 +21295,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/25/Shutter_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shutter_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shutter_Girl"
       },
       {
         "name": "Sif",
@@ -21312,7 +21312,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/38/Sif.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sif"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sif"
       },
       {
         "name": "Skoll The Hunter",
@@ -21329,7 +21329,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Skoll_The_Hunter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skoll_The_Hunter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skoll_The_Hunter"
       },
       {
         "name": "Skymaid",
@@ -21346,7 +21346,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3b/Skymaid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skymaid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skymaid"
       },
       {
         "name": "Star Treker",
@@ -21363,7 +21363,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/10/Star_Treker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Treker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Treker"
       },
       {
         "name": "Storm Hrungnir",
@@ -21376,7 +21376,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bc/Storm_Hrungnir_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Storm_Hrungnir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Storm_Hrungnir"
       },
       {
         "name": "Stunt Driver",
@@ -21393,7 +21393,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/72/Stunt_Driver.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Stunt_Driver"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Stunt_Driver"
       },
       {
         "name": "Summer Oracle",
@@ -21410,7 +21410,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d6/Summer_Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Summer_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Summer_Oracle"
       },
       {
         "name": "Super Iroha",
@@ -21427,7 +21427,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f9/Super_Iroha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Iroha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Iroha"
       },
       {
         "name": "Super Liscia",
@@ -21444,7 +21444,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/86/Super_Liscia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Liscia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Liscia"
       },
       {
         "name": "Sweet Fortuna",
@@ -21461,7 +21461,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1b/Sweet_Fortuna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sweet_Fortuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sweet_Fortuna"
       },
       {
         "name": "Tarot Spirit",
@@ -21482,7 +21482,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/81/Tarot_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tarot_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tarot_Spirit"
       },
       {
         "name": "Teros",
@@ -21499,7 +21499,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/ff/Teros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Teros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Teros"
       },
       {
         "name": "Thalia",
@@ -21516,7 +21516,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/43/Thalia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thalia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thalia"
       },
       {
         "name": "Thrud",
@@ -21533,7 +21533,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4a/Thrud.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thrud"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thrud"
       },
       {
         "name": "Tide",
@@ -21550,7 +21550,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3f/Tide.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tide"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tide"
       },
       {
         "name": "Tishtrya",
@@ -21567,7 +21567,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/37/Tishtrya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tishtrya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tishtrya"
       },
       {
         "name": "Toshigami",
@@ -21584,7 +21584,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/9a/Toshigami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toshigami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toshigami"
       },
       {
         "name": "Troy",
@@ -21601,7 +21601,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2c/Troy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Troy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Troy"
       },
       {
         "name": "True Alpheratz",
@@ -21618,7 +21618,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/74/True_Alpheratz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Alpheratz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Alpheratz"
       },
       {
         "name": "Tsukijo",
@@ -21635,7 +21635,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2d/Tsukijo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tsukijo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tsukijo"
       },
       {
         "name": "Tupsimati",
@@ -21652,7 +21652,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/60/Tupsimati.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tupsimati"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tupsimati"
       },
       {
         "name": "Ullr",
@@ -21669,7 +21669,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/15/Ullr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ullr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ullr"
       },
       {
         "name": "Vanargand",
@@ -21686,7 +21686,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/24/Vanargand.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vanargand"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vanargand"
       },
       {
         "name": "Vegie",
@@ -21703,7 +21703,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2f/Vegie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vegie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vegie"
       },
       {
         "name": "Viele",
@@ -21720,7 +21720,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/85/Viele.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Viele"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Viele"
       },
       {
         "name": "Walpurgis",
@@ -21737,7 +21737,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/19/Walpurgis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Walpurgis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Walpurgis"
       },
       {
         "name": "White Panacea",
@@ -21754,7 +21754,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5e/White_Panacea_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Panacea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Panacea"
       },
       {
         "name": "Wind Chime",
@@ -21771,7 +21771,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4e/Wind_Chime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wind_Chime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wind_Chime"
       },
       {
         "name": "Wolfmaid",
@@ -21788,7 +21788,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/91/Wolfmaid.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wolfmaid"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wolfmaid"
       },
       {
         "name": "Wolfwoman",
@@ -21805,7 +21805,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f1/Wolfwoman.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wolfwoman"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wolfwoman"
       },
       {
         "name": "Xuan Nu",
@@ -21822,7 +21822,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/0f/Xuan_Nu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Xuan_Nu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Xuan_Nu"
       },
       {
         "name": "Yang Guifei",
@@ -21839,7 +21839,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/06/Yang_Guifei.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yang_Guifei"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yang_Guifei"
       },
       {
         "name": "Yggdrasil",
@@ -21860,7 +21860,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3b/Yggdrasil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yggdrasil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yggdrasil"
       },
       {
         "name": "Yuzuriha",
@@ -21877,7 +21877,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Yuzuriha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yuzuriha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yuzuriha"
       },
       {
         "name": "Zeus",
@@ -21894,7 +21894,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3c/Zeus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zeus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zeus"
       },
       {
         "name": "Divine Alpheratz",
@@ -21919,7 +21919,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9b/Divine_Alpheratz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Alpheratz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Alpheratz"
       },
       {
         "name": "Doll Hina",
@@ -21944,7 +21944,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c9/Doll_Hina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doll_Hina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doll_Hina"
       },
       {
         "name": "Holly",
@@ -21969,7 +21969,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b8/Holly.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Holly"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Holly"
       },
       {
         "name": "Joan Of Arc",
@@ -21994,7 +21994,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3f/Joan_Of_Arc.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Joan_Of_Arc"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Joan_Of_Arc"
       },
       {
         "name": "Jodie Adventurer",
@@ -22019,7 +22019,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4b/Jodie_Adventurer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jodie_Adventurer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jodie_Adventurer"
       },
       {
         "name": "Lazy Alchemist",
@@ -22044,7 +22044,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/65/Lazy_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lazy_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lazy_Alchemist"
       },
       {
         "name": "Norns",
@@ -22069,7 +22069,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9e/Norns.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Norns"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Norns"
       },
       {
         "name": "Ooyamatsumi",
@@ -22094,7 +22094,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c7/Ooyamatsumi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ooyamatsumi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ooyamatsumi"
       },
       {
         "name": "Qiao Sisters",
@@ -22119,7 +22119,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/29/Qiao_Sisters.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Qiao_Sisters"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Qiao_Sisters"
       },
       {
         "name": "Sacred Pixie",
@@ -22144,7 +22144,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a5/Sacred_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sacred_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sacred_Pixie"
       },
       {
         "name": "Sleepy Hades",
@@ -22169,7 +22169,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c9/Sleepy_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sleepy_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sleepy_Hades"
       },
       {
         "name": "Al",
@@ -22182,7 +22182,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1a/Al.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Al"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Al"
       },
       {
         "name": "Aquamarine",
@@ -22195,7 +22195,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a2/Aquamarine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aquamarine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aquamarine"
       },
       {
         "name": "Arachne",
@@ -22208,7 +22208,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e0/Arachne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arachne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arachne"
       },
       {
         "name": "Archerhood",
@@ -22221,7 +22221,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/68/Archerhood.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Archerhood"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Archerhood"
       },
       {
         "name": "Ariel (Dark)",
@@ -22234,7 +22234,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/10/Ariel_%28Dark%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ariel_(Dark)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ariel_(Dark)"
       },
       {
         "name": "Balloon Scout",
@@ -22247,7 +22247,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8e/Balloon_Scout.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balloon_Scout"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balloon_Scout"
       },
       {
         "name": "Baphomet",
@@ -22260,7 +22260,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a4/Baphomet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Baphomet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Baphomet"
       },
       {
         "name": "Barong",
@@ -22273,7 +22273,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/20/Barong.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Barong"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Barong"
       },
       {
         "name": "Basilisk",
@@ -22286,7 +22286,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b1/Basilisk.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Basilisk"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Basilisk"
       },
       {
         "name": "Bearclaw",
@@ -22299,7 +22299,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1e/Bearclaw.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bearclaw"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bearclaw"
       },
       {
         "name": "Black Dragon",
@@ -22312,7 +22312,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7b/Black_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Dragon"
       },
       {
         "name": "Black Hole",
@@ -22325,7 +22325,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/23/Black_Hole_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Hole"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Hole"
       },
       {
         "name": "Black Mage",
@@ -22338,7 +22338,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a1/Black_Mage_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Mage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Mage"
       },
       {
         "name": "Casino Owner",
@@ -22351,7 +22351,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/eb/Casino_Owner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Casino_Owner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Casino_Owner"
       },
       {
         "name": "Chimry",
@@ -22364,7 +22364,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a7/Chimry.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chimry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chimry"
       },
       {
         "name": "Choco Wizard",
@@ -22377,7 +22377,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/dc/Choco_Wizard.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Choco_Wizard"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Choco_Wizard"
       },
       {
         "name": "Crimson Cap",
@@ -22390,7 +22390,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/99/Crimson_Cap.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crimson_Cap"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crimson_Cap"
       },
       {
         "name": "Crowley",
@@ -22403,7 +22403,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/16/Crowley.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crowley"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crowley"
       },
       {
         "name": "Crusher",
@@ -22416,7 +22416,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f1/Crusher_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crusher"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crusher"
       },
       {
         "name": "Dagon",
@@ -22429,7 +22429,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c3/Dagon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dagon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dagon"
       },
       {
         "name": "Dark Doctor",
@@ -22442,7 +22442,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c7/Dark_Doctor_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Doctor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Doctor"
       },
       {
         "name": "Dark Knight",
@@ -22455,7 +22455,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/69/Dark_Knight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Knight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Knight"
       },
       {
         "name": "Dark Mage",
@@ -22468,7 +22468,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/33/Dark_Mage.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Mage"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Mage"
       },
       {
         "name": "Dark Mystic",
@@ -22481,7 +22481,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/34/Dark_Mystic.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Mystic"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Mystic"
       },
       {
         "name": "Death",
@@ -22494,7 +22494,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c3/Death.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Death"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Death"
       },
       {
         "name": "Deirdre",
@@ -22507,7 +22507,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f5/Deirdre.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Deirdre"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Deirdre"
       },
       {
         "name": "Devil",
@@ -22520,7 +22520,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2a/Devil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Devil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Devil"
       },
       {
         "name": "Diabolo Star",
@@ -22533,7 +22533,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/65/Diabolo_Star.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diabolo_Star"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diabolo_Star"
       },
       {
         "name": "Dungeon Master",
@@ -22546,7 +22546,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/11/Dungeon_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dungeon_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dungeon_Master"
       },
       {
         "name": "Echidna",
@@ -22559,7 +22559,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/18/Echidna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Echidna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Echidna"
       },
       {
         "name": "Familiar Spirits",
@@ -22572,7 +22572,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/79/Familiar_Spirits.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Familiar_Spirits"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Familiar_Spirits"
       },
       {
         "name": "Free Floater",
@@ -22585,7 +22585,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a4/Free_Floater.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Free_Floater"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Free_Floater"
       },
       {
         "name": "Ghost",
@@ -22598,7 +22598,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/ab/Ghost.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghost"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghost"
       },
       {
         "name": "Golem",
@@ -22611,7 +22611,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/ce/Golem.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Golem"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Golem"
       },
       {
         "name": "Hansel",
@@ -22624,7 +22624,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7a/Hansel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hansel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hansel"
       },
       {
         "name": "Hatter",
@@ -22637,7 +22637,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ee/Hatter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hatter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hatter"
       },
       {
         "name": "Heart Candle",
@@ -22650,7 +22650,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/06/Heart_Candle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Heart_Candle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Heart_Candle"
       },
       {
         "name": "Honey Bear",
@@ -22663,7 +22663,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/13/Honey_Bear.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Honey_Bear"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Honey_Bear"
       },
       {
         "name": "Hotcake",
@@ -22676,7 +22676,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/39/Hotcake.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hotcake"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hotcake"
       },
       {
         "name": "Inquisitor",
@@ -22689,7 +22689,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f5/Inquisitor_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Inquisitor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Inquisitor"
       },
       {
         "name": "Jade-Faced Princess",
@@ -22702,7 +22702,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/03/Jade-Faced_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jade-Faced_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jade-Faced_Princess"
       },
       {
         "name": "Kejoro",
@@ -22715,7 +22715,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/9/90/Kejoro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kejoro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kejoro"
       },
       {
         "name": "Ketu",
@@ -22728,7 +22728,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b1/Ketu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ketu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ketu"
       },
       {
         "name": "Kjersti",
@@ -22741,7 +22741,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c1/Kjersti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kjersti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kjersti"
       },
       {
         "name": "Lesser Demon",
@@ -22754,7 +22754,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bf/Lesser_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lesser_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lesser_Demon"
       },
       {
         "name": "Little Devil",
@@ -22767,7 +22767,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a1/Little_Devil_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Little_Devil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Little_Devil"
       },
       {
         "name": "Magical Relena",
@@ -22780,7 +22780,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cb/Magical_Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Magical_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Magical_Relena"
       },
       {
         "name": "Mech Angel",
@@ -22793,7 +22793,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d1/Mech_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mech_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mech_Angel"
       },
       {
         "name": "Metronome",
@@ -22806,7 +22806,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1c/Metronome.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Metronome"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Metronome"
       },
       {
         "name": "Miduhanome",
@@ -22819,7 +22819,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/34/Miduhanome.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Miduhanome"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Miduhanome"
       },
       {
         "name": "Milk",
@@ -22832,7 +22832,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/92/Milk.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Milk"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Milk"
       },
       {
         "name": "Mind Flayer",
@@ -22845,7 +22845,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/99/Mind_Flayer_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mind_Flayer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mind_Flayer"
       },
       {
         "name": "Nanny",
@@ -22858,7 +22858,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/2b/Nanny.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nanny"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nanny"
       },
       {
         "name": "Necromancer",
@@ -22871,7 +22871,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5d/Necromancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Necromancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Necromancer"
       },
       {
         "name": "Nephthys",
@@ -22884,7 +22884,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b5/Nephthys_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nephthys"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nephthys"
       },
       {
         "name": "Nue",
@@ -22897,7 +22897,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1c/Nue.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nue"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nue"
       },
       {
         "name": "Oni",
@@ -22910,7 +22910,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/bc/Oni.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oni"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oni"
       },
       {
         "name": "Orc",
@@ -22923,7 +22923,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bf/Orc.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Orc"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Orc"
       },
       {
         "name": "Poison",
@@ -22936,7 +22936,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/05/Poison.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Poison"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Poison"
       },
       {
         "name": "Present Pirate",
@@ -22949,7 +22949,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d1/Present_Pirate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Present_Pirate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Present_Pirate"
       },
       {
         "name": "Prisoner",
@@ -22962,7 +22962,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b8/Prisoner_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Prisoner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Prisoner"
       },
       {
         "name": "Rangda",
@@ -22975,7 +22975,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3c/Rangda.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rangda"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rangda"
       },
       {
         "name": "Rapunzel",
@@ -22988,7 +22988,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fd/Rapunzel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rapunzel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rapunzel"
       },
       {
         "name": "Raziel",
@@ -23001,7 +23001,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e5/Raziel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Raziel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Raziel"
       },
       {
         "name": "Riff",
@@ -23014,7 +23014,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c3/Riff.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Riff"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Riff"
       },
       {
         "name": "Samael",
@@ -23027,7 +23027,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b2/Samael.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Samael"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Samael"
       },
       {
         "name": "Senri",
@@ -23040,7 +23040,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/40/Senri.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Senri"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Senri"
       },
       {
         "name": "Service Attendant",
@@ -23053,7 +23053,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/36/Service_Attendant.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Service_Attendant"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Service_Attendant"
       },
       {
         "name": "Shadow",
@@ -23066,7 +23066,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8e/Shadow.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shadow"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shadow"
       },
       {
         "name": "Shapeshifter",
@@ -23079,7 +23079,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/ff/Shapeshifter.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shapeshifter"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shapeshifter"
       },
       {
         "name": "Sheet Ghost",
@@ -23092,7 +23092,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f0/Sheet_Ghost.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sheet_Ghost"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sheet_Ghost"
       },
       {
         "name": "Skeleton",
@@ -23105,7 +23105,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/23/Skeleton.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skeleton"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skeleton"
       },
       {
         "name": "Skyner",
@@ -23118,7 +23118,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fa/Skyner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Skyner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Skyner"
       },
       {
         "name": "Sniper",
@@ -23131,7 +23131,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8f/Sniper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sniper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sniper"
       },
       {
         "name": "Snowman Magnet",
@@ -23144,7 +23144,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c4/Snowman_Magnet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snowman_Magnet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snowman_Magnet"
       },
       {
         "name": "Succubus",
@@ -23157,7 +23157,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ec/Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Succubus"
       },
       {
         "name": "Thanatos",
@@ -23170,7 +23170,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/9b/Thanatos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thanatos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thanatos"
       },
       {
         "name": "Trickster",
@@ -23183,7 +23183,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/bd/Trickster.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Trickster"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Trickster"
       },
       {
         "name": "Tsuruhime",
@@ -23196,7 +23196,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/38/Tsuruhime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tsuruhime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tsuruhime"
       },
       {
         "name": "Vending Machine",
@@ -23209,7 +23209,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d3/Vending_Machine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vending_Machine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vending_Machine"
       },
       {
         "name": "Vepar",
@@ -23222,7 +23222,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/43/Vepar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vepar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vepar"
       },
       {
         "name": "Wall Demon",
@@ -23235,7 +23235,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9d/Wall_Demon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wall_Demon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wall_Demon"
       },
       {
         "name": "Windmill",
@@ -23248,7 +23248,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/68/Windmill.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Windmill"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Windmill"
       },
       {
         "name": "3rd Hammer",
@@ -23265,7 +23265,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/16/3rd_Hammer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/3rd_Hammer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/3rd_Hammer"
       },
       {
         "name": "Adonis",
@@ -23282,7 +23282,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/67/Adonis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Adonis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Adonis"
       },
       {
         "name": "Ambrosi",
@@ -23299,7 +23299,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/85/Ambrosi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ambrosi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ambrosi"
       },
       {
         "name": "Amfor",
@@ -23316,7 +23316,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/01/Amfor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amfor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amfor"
       },
       {
         "name": "Angra Mainyu",
@@ -23329,7 +23329,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e8/Angra_Mainyu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angra_Mainyu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angra_Mainyu"
       },
       {
         "name": "Anya",
@@ -23346,7 +23346,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/56/Anya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anya"
       },
       {
         "name": "Asmodeus",
@@ -23359,7 +23359,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/34/Asmodeus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asmodeus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asmodeus"
       },
       {
         "name": "Asta",
@@ -23376,7 +23376,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/51/Asta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asta"
       },
       {
         "name": "Astaroth",
@@ -23389,7 +23389,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c7/Astaroth_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astaroth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astaroth"
       },
       {
         "name": "Azazel",
@@ -23402,7 +23402,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/42/Azazel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Azazel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Azazel"
       },
       {
         "name": "Balam",
@@ -23419,7 +23419,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7a/Balam.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balam"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balam"
       },
       {
         "name": "Balor",
@@ -23432,7 +23432,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/67/Balor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Balor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Balor"
       },
       {
         "name": "Beelzebub",
@@ -23445,7 +23445,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bf/Beelzebub.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beelzebub"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beelzebub"
       },
       {
         "name": "Belial",
@@ -23462,7 +23462,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/de/Belial_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Belial"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Belial"
       },
       {
         "name": "Belphegor",
@@ -23475,7 +23475,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/11/Belphegor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Belphegor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Belphegor"
       },
       {
         "name": "Bianca",
@@ -23488,7 +23488,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d6/Bianca.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bianca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bianca"
       },
       {
         "name": "Biblio",
@@ -23505,7 +23505,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/79/Biblio.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Biblio"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Biblio"
       },
       {
         "name": "Bicorn",
@@ -23518,7 +23518,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/ff/Bicorn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bicorn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bicorn"
       },
       {
         "name": "Black Tortoise",
@@ -23531,7 +23531,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/22/Black_Tortoise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Tortoise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Tortoise"
       },
       {
         "name": "Bona",
@@ -23548,7 +23548,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/77/Bona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bona"
       },
       {
         "name": "Brioche",
@@ -23561,7 +23561,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/99/Brioche.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brioche"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brioche"
       },
       {
         "name": "Brule",
@@ -23574,7 +23574,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0a/Brule.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Brule"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Brule"
       },
       {
         "name": "Burglar",
@@ -23587,7 +23587,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/29/Burglar.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Burglar"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Burglar"
       },
       {
         "name": "Camilla",
@@ -23600,7 +23600,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Camilla.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Camilla"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Camilla"
       },
       {
         "name": "Candy",
@@ -23617,7 +23617,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1c/Candy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Candy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Candy"
       },
       {
         "name": "Cao Cao",
@@ -23634,7 +23634,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b0/Cao_Cao.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cao_Cao"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cao_Cao"
       },
       {
         "name": "Catagion",
@@ -23647,7 +23647,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/13/Catagion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Catagion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Catagion"
       },
       {
         "name": "Champion",
@@ -23660,7 +23660,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d7/Champion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Champion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Champion"
       },
       {
         "name": "Chandra",
@@ -23677,7 +23677,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/dd/Chandra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chandra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chandra"
       },
       {
         "name": "Chang'E",
@@ -23694,7 +23694,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/94/Chang%27E.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chang%27E"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chang%27E"
       },
       {
         "name": "Chaos",
@@ -23707,7 +23707,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8f/Chaos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chaos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chaos"
       },
       {
         "name": "Charlemagne",
@@ -23720,7 +23720,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/6e/Charlemagne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Charlemagne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Charlemagne"
       },
       {
         "name": "Chocodevil",
@@ -23733,7 +23733,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0b/Chocodevil.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chocodevil"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chocodevil"
       },
       {
         "name": "Cirque du Luna",
@@ -23746,7 +23746,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/5c/Cirque_du_Luna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cirque_du_Luna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cirque_du_Luna"
       },
       {
         "name": "Claudius",
@@ -23759,7 +23759,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f7/Claudius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Claudius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Claudius"
       },
       {
         "name": "Comfy Cat",
@@ -23776,7 +23776,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/40/Comfy_Cat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Comfy_Cat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Comfy_Cat"
       },
       {
         "name": "Corvus",
@@ -23793,7 +23793,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/f3/Corvus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Corvus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Corvus"
       },
       {
         "name": "Count Down",
@@ -23806,7 +23806,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3c/Count_Down.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Count_Down"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Count_Down"
       },
       {
         "name": "Court Lady Anya",
@@ -23823,7 +23823,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/06/Court_Lady_Anya_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Court_Lady_Anya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Court_Lady_Anya"
       },
       {
         "name": "Cpt. Bianca",
@@ -23836,7 +23836,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/40/Cpt._Bianca_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cpt._Bianca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cpt._Bianca"
       },
       {
         "name": "Dark Alice",
@@ -23849,7 +23849,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3c/Dark_Alice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Alice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Alice"
       },
       {
         "name": "Dark Fairy",
@@ -23862,7 +23862,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/dc/Dark_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Fairy"
       },
       {
         "name": "Dark Santa",
@@ -23875,7 +23875,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/47/Dark_Santa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Santa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Santa"
       },
       {
         "name": "Data Scanner",
@@ -23892,7 +23892,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/00/Data_Scanner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Data_Scanner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Data_Scanner"
       },
       {
         "name": "Decarabia",
@@ -23905,7 +23905,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7d/Decarabia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Decarabia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Decarabia"
       },
       {
         "name": "Demon Lord",
@@ -23918,7 +23918,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ec/Demon_Lord.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demon_Lord"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demon_Lord"
       },
       {
         "name": "Diana",
@@ -23931,7 +23931,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/95/Diana_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diana"
       },
       {
         "name": "Doris",
@@ -23948,7 +23948,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/02/Doris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doris"
       },
       {
         "name": "Durandal",
@@ -23961,7 +23961,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5b/Durandal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Durandal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Durandal"
       },
       {
         "name": "Eleusis",
@@ -23978,7 +23978,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b4/Eleusis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eleusis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eleusis"
       },
       {
         "name": "Elisabeth",
@@ -23991,7 +23991,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/63/Elisabeth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elisabeth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elisabeth"
       },
       {
         "name": "Erakis",
@@ -24008,7 +24008,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/eb/Erakis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Erakis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Erakis"
       },
       {
         "name": "Eucharis",
@@ -24025,7 +24025,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2b/Eucharis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eucharis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eucharis"
       },
       {
         "name": "Evelyne",
@@ -24038,7 +24038,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/ea/Evelyne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Evelyne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Evelyne"
       },
       {
         "name": "Farris",
@@ -24055,7 +24055,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/dd/Farris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Farris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Farris"
       },
       {
         "name": "Fennec",
@@ -24072,7 +24072,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/91/Fennec.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fennec"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fennec"
       },
       {
         "name": "Flu",
@@ -24085,7 +24085,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/80/Flu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flu"
       },
       {
         "name": "Follower Ketu",
@@ -24098,7 +24098,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/ca/Follower_Ketu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Follower_Ketu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Follower_Ketu"
       },
       {
         "name": "Forneus",
@@ -24115,7 +24115,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/02/Forneus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Forneus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Forneus"
       },
       {
         "name": "Freischutz",
@@ -24128,7 +24128,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2b/Freischutz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Freischutz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Freischutz"
       },
       {
         "name": "Fuga",
@@ -24145,7 +24145,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/55/Fuga.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fuga"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fuga"
       },
       {
         "name": "Fukori",
@@ -24162,7 +24162,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b3/Fukori.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fukori"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fukori"
       },
       {
         "name": "Gaap",
@@ -24175,7 +24175,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/9a/Gaap.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gaap"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gaap"
       },
       {
         "name": "Glasya",
@@ -24192,7 +24192,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e3/Glasya.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Glasya"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Glasya"
       },
       {
         "name": "Graveyard Queen",
@@ -24205,7 +24205,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7c/Graveyard_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Graveyard_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Graveyard_Queen"
       },
       {
         "name": "Gretel",
@@ -24218,7 +24218,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/09/Gretel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gretel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gretel"
       },
       {
         "name": "Guardian Relena",
@@ -24231,7 +24231,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/ab/Guardian_Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Guardian_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Guardian_Relena"
       },
       {
         "name": "Hades",
@@ -24244,7 +24244,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/64/Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hades"
       },
       {
         "name": "Hammock Babe",
@@ -24257,7 +24257,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bb/Hammock_Babe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hammock_Babe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hammock_Babe"
       },
       {
         "name": "Hecate",
@@ -24274,7 +24274,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/ae/Hecate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hecate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hecate"
       },
       {
         "name": "Hell's Kitchen",
@@ -24291,7 +24291,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4e/Hell%27s_Kitchen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hell%27s_Kitchen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hell%27s_Kitchen"
       },
       {
         "name": "High Succubus",
@@ -24316,7 +24316,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/67/High_Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/High_Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/High_Succubus"
       },
       {
         "name": "High Vampire",
@@ -24333,7 +24333,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/06/High_Vampire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/High_Vampire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/High_Vampire"
       },
       {
         "name": "Hiruko",
@@ -24346,7 +24346,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d6/Hiruko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hiruko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hiruko"
       },
       {
         "name": "Huang Gai",
@@ -24359,7 +24359,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/95/Huang_Gai.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Huang_Gai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Huang_Gai"
       },
       {
         "name": "Hypnos",
@@ -24372,7 +24372,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/71/Hypnos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hypnos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hypnos"
       },
       {
         "name": "Inadama",
@@ -24389,7 +24389,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/65/Inadama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Inadama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Inadama"
       },
       {
         "name": "Infernal Hades",
@@ -24406,7 +24406,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a5/Infernal_Hades.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Infernal_Hades"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Infernal_Hades"
       },
       {
         "name": "Izanami",
@@ -24419,7 +24419,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5e/Izanami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Izanami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Izanami"
       },
       {
         "name": "Jack-O'-Sisters",
@@ -24436,7 +24436,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c6/Jack-O%27-Sisters.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jack-O%27-Sisters"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jack-O%27-Sisters"
       },
       {
         "name": "Jingle Bell",
@@ -24449,7 +24449,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8a/Jingle_Bell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jingle_Bell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jingle_Bell"
       },
       {
         "name": "Joker",
@@ -24466,7 +24466,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ef/Joker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Joker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Joker"
       },
       {
         "name": "Joker (Cane)",
@@ -24483,7 +24483,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ec/Joker_%28Cane%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Joker_(Cane)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Joker_(Cane)"
       },
       {
         "name": "Joker (Sickle)",
@@ -24500,7 +24500,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8a/Joker_%28Sickle%29_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Joker_(Sickle)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Joker_(Sickle)"
       },
       {
         "name": "Jubilee Hostess",
@@ -24513,7 +24513,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/75/Jubilee_Hostess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jubilee_Hostess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jubilee_Hostess"
       },
       {
         "name": "Kendama",
@@ -24530,7 +24530,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b4/Kendama.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kendama"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kendama"
       },
       {
         "name": "Keymaker",
@@ -24543,7 +24543,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/46/Keymaker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Keymaker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Keymaker"
       },
       {
         "name": "Lakka",
@@ -24556,7 +24556,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8d/Lakka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lakka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lakka"
       },
       {
         "name": "Le Repas",
@@ -24569,7 +24569,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4c/Le_Repas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Le_Repas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Le_Repas"
       },
       {
         "name": "Leviathan",
@@ -24582,7 +24582,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0a/Leviathan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leviathan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leviathan"
       },
       {
         "name": "Lich",
@@ -24595,7 +24595,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/86/Lich.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lich"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lich"
       },
       {
         "name": "Lil' Vampire",
@@ -24608,7 +24608,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e7/Lil%27_Vampire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lil%27_Vampire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lil%27_Vampire"
       },
       {
         "name": "Lilim",
@@ -24625,7 +24625,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/75/Lilim.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lilim"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lilim"
       },
       {
         "name": "Lolli",
@@ -24638,7 +24638,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/a8/Lolli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lolli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lolli"
       },
       {
         "name": "Lost Fairy",
@@ -24651,7 +24651,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/ba/Lost_Fairy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lost_Fairy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lost_Fairy"
       },
       {
         "name": "Love Sniper",
@@ -24664,7 +24664,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d1/Love_Sniper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Love_Sniper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Love_Sniper"
       },
       {
         "name": "Lovely",
@@ -24681,7 +24681,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/37/Lovely.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lovely"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lovely"
       },
       {
         "name": "Lu Bu",
@@ -24694,7 +24694,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d2/Lu_Bu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lu_Bu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lu_Bu"
       },
       {
         "name": "Lucifer",
@@ -24707,7 +24707,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/00/Lucifer_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucifer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucifer"
       },
       {
         "name": "Lynx",
@@ -24720,7 +24720,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b8/Lynx.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lynx"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lynx"
       },
       {
         "name": "Mai Waifu",
@@ -24733,7 +24733,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1a/Mai_Waifu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mai_Waifu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mai_Waifu"
       },
       {
         "name": "Mammon",
@@ -24746,7 +24746,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0f/Mammon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mammon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mammon"
       },
       {
         "name": "Mascotte",
@@ -24763,7 +24763,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/47/Mascotte.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mascotte"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mascotte"
       },
       {
         "name": "Matcha",
@@ -24776,7 +24776,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/2e/Matcha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Matcha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Matcha"
       },
       {
         "name": "Mephistopheles",
@@ -24789,7 +24789,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9d/Mephistopheles.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mephistopheles"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mephistopheles"
       },
       {
         "name": "Merlin",
@@ -24806,7 +24806,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a6/Merlin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Merlin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Merlin"
       },
       {
         "name": "Nadia",
@@ -24819,7 +24819,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1b/Nadia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nadia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nadia"
       },
       {
         "name": "Nightingale",
@@ -24832,7 +24832,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7c/Nightingale.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nightingale"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nightingale"
       },
       {
         "name": "Nightmare",
@@ -24845,7 +24845,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/9/9b/Nightmare.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nightmare"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nightmare"
       },
       {
         "name": "Nyx",
@@ -24858,7 +24858,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8e/Nyx.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nyx"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nyx"
       },
       {
         "name": "Pandora",
@@ -24871,7 +24871,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/94/Pandora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pandora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pandora"
       },
       {
         "name": "Polar Night",
@@ -24888,7 +24888,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e8/Polar_Night_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Polar_Night"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Polar_Night"
       },
       {
         "name": "Pollux",
@@ -24901,7 +24901,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7b/Pollux.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pollux"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pollux"
       },
       {
         "name": "Pretty Kitty",
@@ -24918,7 +24918,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b0/Pretty_Kitty.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pretty_Kitty"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pretty_Kitty"
       },
       {
         "name": "Producer",
@@ -24935,7 +24935,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/ad/Producer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Producer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Producer"
       },
       {
         "name": "Queen Succubus",
@@ -24952,7 +24952,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cb/Queen_Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Queen_Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Queen_Succubus"
       },
       {
         "name": "Randgrith",
@@ -24969,7 +24969,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/02/Randgrith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Randgrith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Randgrith"
       },
       {
         "name": "Rathgrith",
@@ -24986,7 +24986,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/19/Rathgrith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rathgrith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rathgrith"
       },
       {
         "name": "Red Girl",
@@ -24999,7 +24999,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7f/Red_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Girl"
       },
       {
         "name": "Red String",
@@ -25012,7 +25012,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/22/Red_String.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_String"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_String"
       },
       {
         "name": "Resistance",
@@ -25025,7 +25025,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4b/Resistance.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Resistance"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Resistance"
       },
       {
         "name": "Rientes",
@@ -25042,7 +25042,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Rientes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rientes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rientes"
       },
       {
         "name": "Rikayu in Chains",
@@ -25055,7 +25055,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/74/Rikayu_in_Chains.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rikayu_in_Chains"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rikayu_in_Chains"
       },
       {
         "name": "Ripple",
@@ -25072,7 +25072,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/23/Ripple.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ripple"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ripple"
       },
       {
         "name": "Roro",
@@ -25085,7 +25085,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cb/Roro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roro"
       },
       {
         "name": "Rossa",
@@ -25098,7 +25098,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f2/Rossa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rossa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rossa"
       },
       {
         "name": "Ruel",
@@ -25115,7 +25115,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/23/Ruel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ruel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ruel"
       },
       {
         "name": "Ruru",
@@ -25128,7 +25128,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/cf/Ruru.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ruru"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ruru"
       },
       {
         "name": "Sandcastle Girl",
@@ -25141,7 +25141,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a5/Sandcastle_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sandcastle_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sandcastle_Girl"
       },
       {
         "name": "Sanja",
@@ -25158,7 +25158,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/81/Sanja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sanja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sanja"
       },
       {
         "name": "Satan",
@@ -25171,7 +25171,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e2/Satan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Satan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Satan"
       },
       {
         "name": "School Spirit",
@@ -25184,7 +25184,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e2/School_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/School_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/School_Spirit"
       },
       {
         "name": "Semiramis",
@@ -25197,7 +25197,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a3/Semiramis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Semiramis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Semiramis"
       },
       {
         "name": "Shark",
@@ -25210,7 +25210,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/14/Shark.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shark"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shark"
       },
       {
         "name": "Snow White",
@@ -25227,7 +25227,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e6/Snow_White.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snow_White"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snow_White"
       },
       {
         "name": "Sorbet",
@@ -25240,7 +25240,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/63/Sorbet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sorbet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sorbet"
       },
       {
         "name": "Star Erakis",
@@ -25257,7 +25257,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/01/Star_Erakis_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Erakis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Erakis"
       },
       {
         "name": "Subleader One",
@@ -25270,7 +25270,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/ce/Subleader_One.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Subleader_One"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Subleader_One"
       },
       {
         "name": "Super Chimry",
@@ -25283,7 +25283,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/72/Super_Chimry_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Chimry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Chimry"
       },
       {
         "name": "Super Chimry (Dark)",
@@ -25296,7 +25296,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f7/Super_Chimry_%28Dark%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Chimry_(Dark)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Chimry_(Dark)"
       },
       {
         "name": "Surtr",
@@ -25309,7 +25309,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/13/Surtr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Surtr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Surtr"
       },
       {
         "name": "Susa-No-O",
@@ -25326,7 +25326,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1e/Susa-No-O.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Susa-No-O"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Susa-No-O"
       },
       {
         "name": "Sylphis",
@@ -25347,7 +25347,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/26/Sylphis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sylphis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sylphis"
       },
       {
         "name": "Tagirihime",
@@ -25360,7 +25360,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0b/Tagirihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tagirihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tagirihime"
       },
       {
         "name": "Taishi Ci",
@@ -25373,7 +25373,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/46/Taishi_Ci.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Taishi_Ci"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Taishi_Ci"
       },
       {
         "name": "Takamine",
@@ -25386,7 +25386,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/3/3f/Takamine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Takamine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Takamine"
       },
       {
         "name": "Tiel",
@@ -25403,7 +25403,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e3/Tiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tiel"
       },
       {
         "name": "Tino",
@@ -25420,7 +25420,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/28/Tino.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tino"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tino"
       },
       {
         "name": "Toilet Ghost",
@@ -25433,7 +25433,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/97/Toilet_Ghost.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toilet_Ghost"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toilet_Ghost"
       },
       {
         "name": "Trident",
@@ -25446,7 +25446,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/9a/Trident.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Trident"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Trident"
       },
       {
         "name": "Vallee",
@@ -25463,7 +25463,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/52/Vallee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vallee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vallee"
       },
       {
         "name": "Vampire",
@@ -25480,7 +25480,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4e/Vampire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vampire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vampire"
       },
       {
         "name": "Vampire Slayer",
@@ -25493,7 +25493,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/2/2f/Vampire_Slayer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vampire_Slayer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vampire_Slayer"
       },
       {
         "name": "Vector",
@@ -25506,7 +25506,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/2/27/Vector.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vector"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vector"
       },
       {
         "name": "Vermillion",
@@ -25523,7 +25523,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/c/c4/Vermillion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vermillion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vermillion"
       },
       {
         "name": "Veronica",
@@ -25536,7 +25536,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/83/Veronica.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Veronica"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Veronica"
       },
       {
         "name": "Virus Killer",
@@ -25553,7 +25553,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/da/Virus_Killer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virus_Killer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virus_Killer"
       },
       {
         "name": "Vrykolakas",
@@ -25570,7 +25570,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/12/Vrykolakas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vrykolakas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vrykolakas"
       },
       {
         "name": "Watz",
@@ -25587,7 +25587,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a1/Watz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Watz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Watz"
       },
       {
         "name": "Weaponsmith",
@@ -25604,7 +25604,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a6/Weaponsmith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Weaponsmith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Weaponsmith"
       },
       {
         "name": "White Dragon Horse",
@@ -25617,7 +25617,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b9/White_Dragon_Horse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/White_Dragon_Horse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/White_Dragon_Horse"
       },
       {
         "name": "Yakshini",
@@ -25630,7 +25630,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/78/Yakshini.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yakshini"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yakshini"
       },
       {
         "name": "Yuki Onna",
@@ -25647,7 +25647,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f5/Yuki_Onna_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yuki_Onna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yuki_Onna"
       },
       {
         "name": "Able Evelyne",
@@ -25664,7 +25664,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8e/Able_Evelyne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Able_Evelyne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Able_Evelyne"
       },
       {
         "name": "Aeolia",
@@ -25681,7 +25681,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ef/Aeolia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aeolia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aeolia"
       },
       {
         "name": "Aestas",
@@ -25698,7 +25698,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/96/Aestas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aestas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aestas"
       },
       {
         "name": "Ali Baba",
@@ -25715,7 +25715,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/14/Ali_Baba.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ali_Baba"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ali_Baba"
       },
       {
         "name": "Alien Maxwell",
@@ -25732,7 +25732,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2d/Alien_Maxwell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alien_Maxwell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alien_Maxwell"
       },
       {
         "name": "Almach",
@@ -25749,7 +25749,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/19/Almach.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Almach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Almach"
       },
       {
         "name": "Amduscias",
@@ -25766,7 +25766,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e3/Amduscias.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amduscias"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amduscias"
       },
       {
         "name": "Amor",
@@ -25783,7 +25783,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/14/Amor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amor"
       },
       {
         "name": "Anglerfish",
@@ -25800,7 +25800,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/64/Anglerfish.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anglerfish"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anglerfish"
       },
       {
         "name": "Annaberge",
@@ -25817,7 +25817,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/bf/Annaberge.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Annaberge"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Annaberge"
       },
       {
         "name": "Antigone",
@@ -25834,7 +25834,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/1e/Antigone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Antigone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Antigone"
       },
       {
         "name": "Arius",
@@ -25851,7 +25851,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/93/Arius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arius"
       },
       {
         "name": "Astral Stolas",
@@ -25868,7 +25868,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/cf/Astral_Stolas.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astral_Stolas"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astral_Stolas"
       },
       {
         "name": "Astral Wing",
@@ -25881,7 +25881,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/6/60/Astral_Wing_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Astral_Wing"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Astral_Wing"
       },
       {
         "name": "Atalanta",
@@ -25898,7 +25898,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/89/Atalanta_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Atalanta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Atalanta"
       },
       {
         "name": "Ayeris",
@@ -25915,7 +25915,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1c/Ayeris.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ayeris"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ayeris"
       },
       {
         "name": "Azi Dahaka",
@@ -25932,7 +25932,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/4/4b/Azi_Dahaka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Azi_Dahaka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Azi_Dahaka"
       },
       {
         "name": "Baal",
@@ -25949,7 +25949,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/43/Baal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Baal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Baal"
       },
       {
         "name": "Barista",
@@ -25966,7 +25966,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/05/Barista.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Barista"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Barista"
       },
       {
         "name": "Belly Dancer",
@@ -25983,7 +25983,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Belly_Dancer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Belly_Dancer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Belly_Dancer"
       },
       {
         "name": "Black Lily",
@@ -26000,7 +26000,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1f/Black_Lily.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Black_Lily"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Black_Lily"
       },
       {
         "name": "Blazing Whitecloth",
@@ -26017,7 +26017,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/ff/Blazing_Whitecloth_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blazing_Whitecloth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blazing_Whitecloth"
       },
       {
         "name": "Blue Eyes",
@@ -26034,7 +26034,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d4/Blue_Eyes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blue_Eyes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blue_Eyes"
       },
       {
         "name": "Blue Surtr",
@@ -26051,7 +26051,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4a/Blue_Surtr_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blue_Surtr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blue_Surtr"
       },
       {
         "name": "Blushing Lucy",
@@ -26068,7 +26068,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0d/Blushing_Lucy_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blushing_Lucy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blushing_Lucy"
       },
       {
         "name": "Bondage Babe",
@@ -26085,7 +26085,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c2/Bondage_Babe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bondage_Babe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bondage_Babe"
       },
       {
         "name": "Bonfire",
@@ -26102,7 +26102,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/ff/Bonfire.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bonfire"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bonfire"
       },
       {
         "name": "Bookend",
@@ -26119,7 +26119,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1b/Bookend.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bookend"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bookend"
       },
       {
         "name": "Calamity",
@@ -26136,7 +26136,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/52/Calamity.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Calamity"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Calamity"
       },
       {
         "name": "Candy Alchemist",
@@ -26153,7 +26153,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7b/Candy_Alchemist_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Candy_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Candy_Alchemist"
       },
       {
         "name": "Capone",
@@ -26170,7 +26170,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3f/Capone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Capone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Capone"
       },
       {
         "name": "Captain Saurva",
@@ -26183,7 +26183,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/f/f3/Captain_Saurva_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Saurva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Saurva"
       },
       {
         "name": "Caracal",
@@ -26200,7 +26200,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ae/Caracal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Caracal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Caracal"
       },
       {
         "name": "Carbuncle",
@@ -26217,7 +26217,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7b/Carbuncle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Carbuncle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Carbuncle"
       },
       {
         "name": "Charybdis",
@@ -26234,7 +26234,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/ca/Charybdis.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Charybdis"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Charybdis"
       },
       {
         "name": "Chief Justice Bunny",
@@ -26251,7 +26251,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/95/Chief_Justice_Bunny_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chief_Justice_Bunny"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chief_Justice_Bunny"
       },
       {
         "name": "Cocina",
@@ -26268,7 +26268,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/63/Cocina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cocina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cocina"
       },
       {
         "name": "Collapse",
@@ -26285,7 +26285,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ab/Collapse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Collapse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Collapse"
       },
       {
         "name": "Conjurer",
@@ -26302,7 +26302,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d4/Conjurer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Conjurer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Conjurer"
       },
       {
         "name": "Coppelia",
@@ -26323,7 +26323,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/8d/Coppelia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Coppelia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Coppelia"
       },
       {
         "name": "Cornered Rat",
@@ -26340,7 +26340,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/db/Cornered_Rat.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cornered_Rat"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cornered_Rat"
       },
       {
         "name": "Court Lady Peachy",
@@ -26357,7 +26357,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/67/Court_Lady_Peachy_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Court_Lady_Peachy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Court_Lady_Peachy"
       },
       {
         "name": "Court Lady Utai",
@@ -26374,7 +26374,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Court_Lady_Utai_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Court_Lady_Utai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Court_Lady_Utai"
       },
       {
         "name": "Courtney",
@@ -26399,7 +26399,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ea/Courtney.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Courtney"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Courtney"
       },
       {
         "name": "Crafty Loki",
@@ -26416,7 +26416,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/13/Crafty_Loki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crafty_Loki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crafty_Loki"
       },
       {
         "name": "Cranky Relena",
@@ -26433,7 +26433,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/9/96/Cranky_Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cranky_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cranky_Relena"
       },
       {
         "name": "Crimson Eyes",
@@ -26450,7 +26450,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7c/Crimson_Eyes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crimson_Eyes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crimson_Eyes"
       },
       {
         "name": "Cyaegha",
@@ -26467,7 +26467,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d3/Cyaegha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cyaegha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cyaegha"
       },
       {
         "name": "Daji",
@@ -26484,7 +26484,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/fb/Daji.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Daji"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Daji"
       },
       {
         "name": "Dancing Lion",
@@ -26501,7 +26501,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/ab/Dancing_Lion.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dancing_Lion"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dancing_Lion"
       },
       {
         "name": "Dark Cinderella",
@@ -26518,7 +26518,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/70/Dark_Cinderella.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Cinderella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Cinderella"
       },
       {
         "name": "Dark Sister",
@@ -26535,7 +26535,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ed/Dark_Sister.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dark_Sister"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dark_Sister"
       },
       {
         "name": "Darling Doll",
@@ -26552,7 +26552,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/37/Darling_Doll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Darling_Doll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Darling_Doll"
       },
       {
         "name": "Death Puppet",
@@ -26569,7 +26569,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/48/Death_Puppet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Death_Puppet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Death_Puppet"
       },
       {
         "name": "Death Stalker",
@@ -26586,7 +26586,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e8/Death_Stalker.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Death_Stalker"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Death_Stalker"
       },
       {
         "name": "Demise",
@@ -26603,7 +26603,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/8/82/Demise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demise"
       },
       {
         "name": "Demon Bookend",
@@ -26620,7 +26620,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5c/Demon_Bookend_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Demon_Bookend"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Demon_Bookend"
       },
       {
         "name": "Diaochan",
@@ -26637,7 +26637,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/0/0f/Diaochan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diaochan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diaochan"
       },
       {
         "name": "Diva Aeolia",
@@ -26654,7 +26654,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/32/Diva_Aeolia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Diva_Aeolia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Diva_Aeolia"
       },
       {
         "name": "Dr. Coppelius",
@@ -26675,7 +26675,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b1/Dr._Coppelius_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dr._Coppelius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dr._Coppelius"
       },
       {
         "name": "Elatha",
@@ -26696,7 +26696,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6d/Elatha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elatha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elatha"
       },
       {
         "name": "Enkidu",
@@ -26713,7 +26713,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b0/Enkidu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Enkidu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Enkidu"
       },
       {
         "name": "Executioner",
@@ -26730,7 +26730,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/93/Executioner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Executioner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Executioner"
       },
       {
         "name": "Failnaught",
@@ -26747,7 +26747,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/53/Failnaught.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Failnaught"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Failnaught"
       },
       {
         "name": "Fierce Zhong Kui",
@@ -26764,7 +26764,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/18/Fierce_Zhong_Kui_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fierce_Zhong_Kui"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fierce_Zhong_Kui"
       },
       {
         "name": "Flower Elf",
@@ -26781,7 +26781,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e4/Flower_Elf.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flower_Elf"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flower_Elf"
       },
       {
         "name": "Foras",
@@ -26798,7 +26798,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/41/Foras.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Foras"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Foras"
       },
       {
         "name": "Formal Gan Ning",
@@ -26811,7 +26811,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7e/Formal_Gan_Ning_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Formal_Gan_Ning"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Formal_Gan_Ning"
       },
       {
         "name": "Formula",
@@ -26828,7 +26828,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/cf/Formula.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Formula"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Formula"
       },
       {
         "name": "Fortune Cannon",
@@ -26849,7 +26849,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/d/d8/Fortune_Cannon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fortune_Cannon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fortune_Cannon"
       },
       {
         "name": "Fu Tsu",
@@ -26870,7 +26870,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/b/b3/Fu_Tsu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fu_Tsu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fu_Tsu"
       },
       {
         "name": "Funeral March",
@@ -26887,7 +26887,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/a/a6/Funeral_March.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Funeral_March"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Funeral_March"
       },
       {
         "name": "Gaede",
@@ -26904,7 +26904,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/34/Gaede.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gaede"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gaede"
       },
       {
         "name": "Game Master",
@@ -26925,7 +26925,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/46/Game_Master.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Game_Master"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Game_Master"
       },
       {
         "name": "Gan Ning",
@@ -26942,7 +26942,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/80/Gan_Ning.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gan_Ning"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gan_Ning"
       },
       {
         "name": "Gargoyle",
@@ -26959,7 +26959,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/44/Gargoyle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gargoyle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gargoyle"
       },
       {
         "name": "Genie",
@@ -26976,7 +26976,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8c/Genie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Genie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Genie"
       },
       {
         "name": "Germophile",
@@ -26993,7 +26993,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/e1/Germophile.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Germophile"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Germophile"
       },
       {
         "name": "Ghost Rider",
@@ -27010,7 +27010,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3d/Ghost_Rider.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ghost_Rider"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ghost_Rider"
       },
       {
         "name": "Goth Genie",
@@ -27023,7 +27023,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/b/b7/Goth_Genie_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Goth_Genie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Goth_Genie"
       },
       {
         "name": "Green Dragon",
@@ -27036,7 +27036,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3b/Green_Dragon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Green_Dragon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Green_Dragon"
       },
       {
         "name": "Groa",
@@ -27057,7 +27057,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/50/Groa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Groa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Groa"
       },
       {
         "name": "Gullveig",
@@ -27074,7 +27074,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/49/Gullveig.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gullveig"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gullveig"
       },
       {
         "name": "Gunsmith",
@@ -27091,7 +27091,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/56/Gunsmith.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gunsmith"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gunsmith"
       },
       {
         "name": "Hamlet",
@@ -27108,7 +27108,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/1a/Hamlet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hamlet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hamlet"
       },
       {
         "name": "Haunted Hood",
@@ -27125,7 +27125,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2a/Haunted_Hood.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Haunted_Hood"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Haunted_Hood"
       },
       {
         "name": "Hawkeye",
@@ -27142,7 +27142,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/52/Hawkeye.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hawkeye"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hawkeye"
       },
       {
         "name": "Hellgate",
@@ -27159,7 +27159,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/1/1a/Hellgate.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hellgate"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hellgate"
       },
       {
         "name": "Hole in One",
@@ -27176,7 +27176,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/db/Hole_in_One.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hole_in_One"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hole_in_One"
       },
       {
         "name": "Holme",
@@ -27193,7 +27193,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/5/5d/Holme.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Holme"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Holme"
       },
       {
         "name": "Howling Fenrir",
@@ -27214,7 +27214,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ae/Howling_Fenrir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Howling_Fenrir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Howling_Fenrir"
       },
       {
         "name": "Hyde",
@@ -27231,7 +27231,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/06/Hyde.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyde"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyde"
       },
       {
         "name": "Hyper Chimry",
@@ -27244,7 +27244,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/c/c2/Hyper_Chimry_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Chimry"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Chimry"
       },
       {
         "name": "Hyper Chimry (Dark)",
@@ -27257,7 +27257,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/f2/Hyper_Chimry_%28Dark%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Chimry_(Dark)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Chimry_(Dark)"
       },
       {
         "name": "Ice Wolf Fenrir",
@@ -27274,7 +27274,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/ac/Ice_Wolf_Fenrir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ice_Wolf_Fenrir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ice_Wolf_Fenrir"
       },
       {
         "name": "Immortal Rahu",
@@ -27287,7 +27287,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5c/Immortal_Rahu_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Immortal_Rahu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Immortal_Rahu"
       },
       {
         "name": "Judge Bunny",
@@ -27304,7 +27304,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/1d/Judge_Bunny.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Judge_Bunny"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Judge_Bunny"
       },
       {
         "name": "Kagenui",
@@ -27321,7 +27321,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e8/Kagenui.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kagenui"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kagenui"
       },
       {
         "name": "Kallikantzaros",
@@ -27338,7 +27338,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/5b/Kallikantzaros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kallikantzaros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kallikantzaros"
       },
       {
         "name": "Kaycee",
@@ -27355,7 +27355,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d4/Kaycee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kaycee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kaycee"
       },
       {
         "name": "Kennie",
@@ -27372,7 +27372,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/dd/Kennie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kennie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kennie"
       },
       {
         "name": "Kiyohime",
@@ -27389,7 +27389,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/9/90/Kiyohime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kiyohime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kiyohime"
       },
       {
         "name": "Lapraz",
@@ -27406,7 +27406,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/1/13/Lapraz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lapraz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lapraz"
       },
       {
         "name": "Leisurely Relena",
@@ -27419,7 +27419,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/3/3a/Leisurely_Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leisurely_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leisurely_Relena"
       },
       {
         "name": "Lil' Alchemist",
@@ -27436,7 +27436,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/19/Lil%27_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lil%27_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lil%27_Alchemist"
       },
       {
         "name": "Lucy",
@@ -27453,7 +27453,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/05/Lucy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucy"
       },
       {
         "name": "Magic Whip",
@@ -27470,7 +27470,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/db/Magic_Whip.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Magic_Whip"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Magic_Whip"
       },
       {
         "name": "Maid Raven",
@@ -27487,7 +27487,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/61/Maid_Raven_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maid_Raven"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maid_Raven"
       },
       {
         "name": "Majority",
@@ -27504,7 +27504,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/a/a4/Majority.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Majority"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Majority"
       },
       {
         "name": "Marte",
@@ -27521,7 +27521,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/50/Marte.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Marte"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Marte"
       },
       {
         "name": "Megaphone",
@@ -27538,7 +27538,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/6/62/Megaphone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Megaphone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Megaphone"
       },
       {
         "name": "Mercurius",
@@ -27559,7 +27559,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/6d/Mercurius.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mercurius"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mercurius"
       },
       {
         "name": "Merkur",
@@ -27576,7 +27576,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/dd/Merkur.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Merkur"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Merkur"
       },
       {
         "name": "Mirach",
@@ -27593,7 +27593,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/98/Mirach.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirach"
       },
       {
         "name": "Moloch",
@@ -27610,7 +27610,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d7/Moloch.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Moloch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Moloch"
       },
       {
         "name": "Morgana",
@@ -27627,7 +27627,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/14/Morgana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Morgana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Morgana"
       },
       {
         "name": "Mormo",
@@ -27648,7 +27648,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c2/Mormo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mormo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mormo"
       },
       {
         "name": "Nagatsuki",
@@ -27669,7 +27669,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/0/03/Nagatsuki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nagatsuki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nagatsuki"
       },
       {
         "name": "Necronomicon",
@@ -27686,7 +27686,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/78/Necronomicon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Necronomicon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Necronomicon"
       },
       {
         "name": "Nicois",
@@ -27703,7 +27703,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/6/66/Nicois.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nicois"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nicois"
       },
       {
         "name": "Nithhogg",
@@ -27720,7 +27720,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/ff/Nithhogg.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nithhogg"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nithhogg"
       },
       {
         "name": "Nureonna",
@@ -27737,7 +27737,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/17/Nureonna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nureonna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nureonna"
       },
       {
         "name": "Oninomiko",
@@ -27754,7 +27754,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/dc/Oninomiko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oninomiko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oninomiko"
       },
       {
         "name": "Ooinu",
@@ -27771,7 +27771,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3e/Ooinu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ooinu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ooinu"
       },
       {
         "name": "Ouroboros",
@@ -27788,7 +27788,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/f/fa/Ouroboros.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ouroboros"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ouroboros"
       },
       {
         "name": "Paola",
@@ -27805,7 +27805,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b4/Paola.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Paola"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Paola"
       },
       {
         "name": "Peachy",
@@ -27822,7 +27822,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/94/Peachy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Peachy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Peachy"
       },
       {
         "name": "Perse",
@@ -27839,7 +27839,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/29/Perse.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Perse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Perse"
       },
       {
         "name": "Pinochet",
@@ -27856,7 +27856,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/cb/Pinochet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pinochet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pinochet"
       },
       {
         "name": "Pipe Fox",
@@ -27873,7 +27873,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f2/Pipe_Fox.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pipe_Fox"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pipe_Fox"
       },
       {
         "name": "Poison Claw",
@@ -27890,7 +27890,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/00/Poison_Claw.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Poison_Claw"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Poison_Claw"
       },
       {
         "name": "Poison Tea",
@@ -27907,7 +27907,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/76/Poison_Tea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Poison_Tea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Poison_Tea"
       },
       {
         "name": "Praying Princess",
@@ -27924,7 +27924,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/2/2a/Praying_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Praying_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Praying_Princess"
       },
       {
         "name": "Princess Iron Fan",
@@ -27941,7 +27941,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5c/Princess_Iron_Fan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Princess_Iron_Fan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Princess_Iron_Fan"
       },
       {
         "name": "Puck",
@@ -27958,7 +27958,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/b/b6/Puck.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Puck"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Puck"
       },
       {
         "name": "Puppeteer",
@@ -27975,7 +27975,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7a/Puppeteer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Puppeteer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Puppeteer"
       },
       {
         "name": "Puppetmaster",
@@ -27992,7 +27992,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/a/aa/Puppetmaster.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Puppetmaster"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Puppetmaster"
       },
       {
         "name": "Radiant Cinderella",
@@ -28005,7 +28005,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/f5/Radiant_Cinderella_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Radiant_Cinderella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Radiant_Cinderella"
       },
       {
         "name": "Rahu",
@@ -28022,7 +28022,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/81/Rahu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rahu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rahu"
       },
       {
         "name": "Raven",
@@ -28039,7 +28039,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/66/Raven.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Raven"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Raven"
       },
       {
         "name": "Redeye",
@@ -28056,7 +28056,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/6/6b/Redeye.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Redeye"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Redeye"
       },
       {
         "name": "Relena",
@@ -28081,7 +28081,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/7/7b/Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Relena"
       },
       {
         "name": "Rene",
@@ -28098,7 +28098,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c2/Rene.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rene"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rene"
       },
       {
         "name": "Rium",
@@ -28115,7 +28115,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/55/Rium.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rium"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rium"
       },
       {
         "name": "Sabnock",
@@ -28132,7 +28132,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/8e/Sabnock.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sabnock"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sabnock"
       },
       {
         "name": "Santa Relena",
@@ -28149,7 +28149,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/d/d9/Santa_Relena_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Santa_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Santa_Relena"
       },
       {
         "name": "Saurva",
@@ -28166,7 +28166,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/e/ea/Saurva.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Saurva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Saurva"
       },
       {
         "name": "Schwartz",
@@ -28187,7 +28187,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/3/3a/Schwartz.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Schwartz"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Schwartz"
       },
       {
         "name": "Scorching Surtr",
@@ -28204,7 +28204,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/69/Scorching_Surtr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scorching_Surtr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scorching_Surtr"
       },
       {
         "name": "Shadow Magician",
@@ -28221,7 +28221,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/21/Shadow_Magician.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shadow_Magician"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shadow_Magician"
       },
       {
         "name": "Shiva",
@@ -28242,7 +28242,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ec/Shiva.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shiva"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shiva"
       },
       {
         "name": "Shrine Tagirihime",
@@ -28259,7 +28259,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/77/Shrine_Tagirihime_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shrine_Tagirihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shrine_Tagirihime"
       },
       {
         "name": "Shuten-Doji",
@@ -28276,7 +28276,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/a1/Shuten-Doji.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shuten-Doji"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shuten-Doji"
       },
       {
         "name": "Snow Flower",
@@ -28293,7 +28293,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bf/Snow_Flower.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Snow_Flower"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Snow_Flower"
       },
       {
         "name": "Sorcerer Slayer",
@@ -28310,7 +28310,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/86/Sorcerer_Slayer.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sorcerer_Slayer"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sorcerer_Slayer"
       },
       {
         "name": "Soul Reaper",
@@ -28327,7 +28327,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/4/4c/Soul_Reaper.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soul_Reaper"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soul_Reaper"
       },
       {
         "name": "Space Conductor",
@@ -28344,7 +28344,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e1/Space_Conductor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Space_Conductor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Space_Conductor"
       },
       {
         "name": "Speedster",
@@ -28361,7 +28361,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/db/Speedster.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Speedster"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Speedster"
       },
       {
         "name": "Spinner",
@@ -28378,7 +28378,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/7/7b/Spinner.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spinner"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spinner"
       },
       {
         "name": "Spinner (New)",
@@ -28395,7 +28395,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/5/56/Spinner_%28New%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Spinner_(New)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Spinner_(New)"
       },
       {
         "name": "Star Almach",
@@ -28412,7 +28412,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/74/Star_Almach_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Almach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Almach"
       },
       {
         "name": "Star Mirach",
@@ -28429,7 +28429,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/46/Star_Mirach_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Star_Mirach"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Star_Mirach"
       },
       {
         "name": "Starlight",
@@ -28446,7 +28446,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/1/15/Starlight.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Starlight"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Starlight"
       },
       {
         "name": "Styx",
@@ -28463,7 +28463,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/75/Styx.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Styx"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Styx"
       },
       {
         "name": "Sukuna-Bikona",
@@ -28480,7 +28480,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/8/80/Sukuna-Bikona.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sukuna-Bikona"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sukuna-Bikona"
       },
       {
         "name": "Sunny Tagirihime",
@@ -28497,7 +28497,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/78/Sunny_Tagirihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sunny_Tagirihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sunny_Tagirihime"
       },
       {
         "name": "Tathlum",
@@ -28514,7 +28514,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/f/fa/Tathlum.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tathlum"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tathlum"
       },
       {
         "name": "Tezcatlipoca",
@@ -28531,7 +28531,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/4/4f/Tezcatlipoca.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tezcatlipoca"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tezcatlipoca"
       },
       {
         "name": "Therapy",
@@ -28548,7 +28548,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/4/4a/Therapy.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Therapy"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Therapy"
       },
       {
         "name": "Time Mage Perse",
@@ -28565,7 +28565,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/e/ed/Time_Mage_Perse_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Time_Mage_Perse"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Time_Mage_Perse"
       },
       {
         "name": "Toto",
@@ -28582,7 +28582,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/8/8d/Toto.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Toto"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Toto"
       },
       {
         "name": "Turkey Girl",
@@ -28599,7 +28599,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/b/b4/Turkey_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Turkey_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Turkey_Girl"
       },
       {
         "name": "Twin Wolf Fenrir",
@@ -28612,7 +28612,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/39/Twin_Wolf_Fenrir_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Twin_Wolf_Fenrir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Twin_Wolf_Fenrir"
       },
       {
         "name": "Utai",
@@ -28629,7 +28629,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Utai.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Utai"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Utai"
       },
       {
         "name": "Vainglory",
@@ -28646,7 +28646,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/e/e2/Vainglory.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vainglory"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vainglory"
       },
       {
         "name": "Whitecloth",
@@ -28667,7 +28667,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/0/0f/Whitecloth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Whitecloth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Whitecloth"
       },
       {
         "name": "Wingless",
@@ -28684,7 +28684,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/3f/Wingless.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wingless"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wingless"
       },
       {
         "name": "Winter Princess",
@@ -28701,7 +28701,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c1/Winter_Princess.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Winter_Princess"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Winter_Princess"
       },
       {
         "name": "Xuanzong",
@@ -28718,7 +28718,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/58/Xuanzong.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Xuanzong"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Xuanzong"
       },
       {
         "name": "Yatagarasu",
@@ -28735,7 +28735,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/7d/Yatagarasu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yatagarasu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yatagarasu"
       },
       {
         "name": "Ymir",
@@ -28760,7 +28760,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/7/7c/Ymir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ymir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ymir"
       },
       {
         "name": "Yuan Shao",
@@ -28777,7 +28777,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/5/5f/Yuan_Shao.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yuan_Shao"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yuan_Shao"
       },
       {
         "name": "Yuzuki",
@@ -28794,7 +28794,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/05/Yuzuki.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yuzuki"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yuzuki"
       },
       {
         "name": "Zhong Kui",
@@ -28811,7 +28811,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/70/Zhong_Kui.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zhong_Kui"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zhong_Kui"
       },
       {
         "name": "Zhou Yu",
@@ -28828,7 +28828,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/23/Zhou_Yu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zhou_Yu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zhou_Yu"
       },
       {
         "name": "Aisling",
@@ -28853,7 +28853,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/25/Aisling.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aisling"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aisling"
       },
       {
         "name": "Bright Tagirihime",
@@ -28878,7 +28878,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/ce/Bright_Tagirihime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bright_Tagirihime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bright_Tagirihime"
       },
       {
         "name": "Deep Succubus",
@@ -28903,7 +28903,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/1/17/Deep_Succubus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Deep_Succubus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Deep_Succubus"
       },
       {
         "name": "Doomed Calamity",
@@ -28928,7 +28928,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Doomed_Calamity.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doomed_Calamity"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doomed_Calamity"
       },
       {
         "name": "Fire God Surtr",
@@ -28953,7 +28953,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e7/Fire_God_Surtr.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fire_God_Surtr"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fire_God_Surtr"
       },
       {
         "name": "Haunt",
@@ -28978,7 +28978,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/37/Haunt.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Haunt"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Haunt"
       },
       {
         "name": "Hyper Catcine",
@@ -29003,7 +29003,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/61/Hyper_Catcine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hyper_Catcine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hyper_Catcine"
       },
       {
         "name": "Inspired Relena",
@@ -29028,7 +29028,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/5/53/Inspired_Relena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Inspired_Relena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Inspired_Relena"
       },
       {
         "name": "Karma",
@@ -29053,7 +29053,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/af/Karma.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Karma"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Karma"
       },
       {
         "name": "Lil' Crimson Eyes",
@@ -29078,7 +29078,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/44/Lil%27_Crimson_Eyes.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lil%27_Crimson_Eyes"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lil%27_Crimson_Eyes"
       },
       {
         "name": "Lucrezia",
@@ -29103,7 +29103,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Lucrezia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucrezia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucrezia"
       },
       {
         "name": "Roskva & Thialfi",
@@ -29128,7 +29128,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/d/d1/Roskva_%26_Thialfi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roskva_%26_Thialfi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roskva_%26_Thialfi"
       },
       {
         "name": "Sauin",
@@ -29153,7 +29153,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Sauin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sauin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sauin"
       },
       {
         "name": "Sun Ce",
@@ -29178,7 +29178,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/44/Sun_Ce.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sun_Ce"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sun_Ce"
       },
       {
         "name": "True Wolf Fenrir",
@@ -29203,7 +29203,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/e2/True_Wolf_Fenrir.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Wolf_Fenrir"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Wolf_Fenrir"
       },
       {
         "name": "Medal Girl",
@@ -29216,7 +29216,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/c/c2/Medal_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medal_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medal_Girl"
       },
       {
         "name": "Metal Slime",
@@ -29229,7 +29229,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/3/33/Metal_Slime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Metal_Slime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Metal_Slime"
       },
       {
         "name": "Mirror Maiden (R)",
@@ -29242,7 +29242,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/2/23/Mirror_Maiden_%28R%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirror_Maiden_(R)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirror_Maiden_(R)"
       },
       {
         "name": "Gold Girl (SR)",
@@ -29255,7 +29255,7 @@
           }
         ],
         "image": "https://vignette4.wikia.nocookie.net/valkyriecrusade/images/c/c3/Gold_Girl_%28SR%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gold_Girl_(SR)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gold_Girl_(SR)"
       },
       {
         "name": "Medal Girl (SR)",
@@ -29268,7 +29268,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/f/ff/Medal_Girl_%28SR%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Medal_Girl_(SR)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Medal_Girl_(SR)"
       },
       {
         "name": "Mirror Maiden (SR)",
@@ -29281,7 +29281,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/a/ab/Mirror_Maiden_%28SR%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirror_Maiden_(SR)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirror_Maiden_(SR)"
       },
       {
         "name": "Slime Queen",
@@ -29294,7 +29294,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/7/79/Slime_Queen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Slime_Queen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Slime_Queen"
       },
       {
         "name": "Mirror Maiden (UR)",
@@ -29307,7 +29307,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/e/ef/Mirror_Maiden_%28UR%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirror_Maiden_(UR)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirror_Maiden_(UR)"
       },
       {
         "name": "Slime Queen＋",
@@ -29320,7 +29320,7 @@
           }
         ],
         "image": "https://vignette3.wikia.nocookie.net/valkyriecrusade/images/0/0c/Slime_Queen%EF%BC%8B.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Slime_Queen%EF%BC%8B"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Slime_Queen%EF%BC%8B"
       },
       {
         "name": "Super Medal Girl",
@@ -29333,7 +29333,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/87/Super_Medal_Girl.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Super_Medal_Girl"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Super_Medal_Girl"
       },
       {
         "name": "Mirror Maiden (LR)",
@@ -29346,7 +29346,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c8/Mirror_Maiden_%28LR%29.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirror_Maiden_(LR)"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirror_Maiden_(LR)"
       },
       {
         "name": "Jean",
@@ -29363,7 +29363,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2e/Jean.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jean"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jean"
       },
       {
         "name": "Juliet",
@@ -29380,7 +29380,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Juliet.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Juliet"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Juliet"
       },
       {
         "name": "Maxwell",
@@ -29393,7 +29393,7 @@
           }
         ],
         "image": "https://vignette1.wikia.nocookie.net/valkyriecrusade/images/d/d5/Maxwell.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maxwell"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maxwell"
       },
       {
         "name": "Hervor",
@@ -29406,7 +29406,7 @@
           }
         ],
         "image": "https://vignette2.wikia.nocookie.net/valkyriecrusade/images/8/8a/Hervor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hervor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hervor"
       },
       {
         "name": "Palladio",
@@ -29419,7 +29419,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/48/Palladio.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Palladio"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Palladio"
       },
       {
         "name": "Wayland",
@@ -29436,7 +29436,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/28/Wayland.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wayland"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wayland"
       },
       {
         "name": "Preening Wayland",
@@ -29449,7 +29449,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/12/Preening_Wayland_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Preening_Wayland"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Preening_Wayland"
       },
       {
         "name": "Manaslu",
@@ -29466,7 +29466,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/08/Manaslu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Manaslu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Manaslu"
       },
       {
         "name": "Ninhursag",
@@ -29491,7 +29491,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/19/Ninhursag.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ninhursag"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ninhursag"
       },
       {
         "name": "Bayard",
@@ -29508,7 +29508,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e8/Bayard.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bayard"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bayard"
       },
       {
         "name": "Sedgwick",
@@ -29525,7 +29525,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c8/Sedgwick.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sedgwick"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sedgwick"
       },
       {
         "name": "Mithrin",
@@ -29542,7 +29542,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/68/Mithrin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mithrin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mithrin"
       },
       {
         "name": "Kotka",
@@ -29559,7 +29559,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/24/Kotka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kotka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kotka"
       },
       {
         "name": "Uitan",
@@ -29576,7 +29576,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b7/Uitan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Uitan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Uitan"
       },
       {
         "name": "Cozily",
@@ -29593,7 +29593,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/93/Cozily.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cozily"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cozily"
       },
       {
         "name": "Bunny Cozily",
@@ -29610,7 +29610,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2f/Bunny_Cozily_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Bunny_Cozily"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Bunny_Cozily"
       },
       {
         "name": "Palella",
@@ -29627,7 +29627,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4f/Palella.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Palella"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Palella"
       },
       {
         "name": "Deus Ex Machina",
@@ -29652,7 +29652,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b7/Deus_Ex_Machina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Deus_Ex_Machina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Deus_Ex_Machina"
       },
       {
         "name": "Dragon Angel",
@@ -29677,7 +29677,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ae/Dragon_Angel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dragon_Angel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dragon_Angel"
       },
       {
         "name": "Lucky Fortuna",
@@ -29710,7 +29710,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/63/Lucky_Fortuna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lucky_Fortuna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lucky_Fortuna"
       },
       {
         "name": "Divine Eos",
@@ -29723,7 +29723,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f9/Divine_Eos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Eos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Eos"
       },
       {
         "name": "Mystic Eos",
@@ -29740,7 +29740,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9e/Mystic_Eos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mystic_Eos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mystic_Eos"
       },
       {
         "name": "Dancing Eos",
@@ -29757,7 +29757,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/da/Dancing_Eos_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dancing_Eos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dancing_Eos"
       },
       {
         "name": "Moonshadow Eos",
@@ -29782,7 +29782,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/16/Moonshadow_Eos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Moonshadow_Eos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Moonshadow_Eos"
       },
       {
         "name": "Galileo",
@@ -29799,7 +29799,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Galileo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Galileo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Galileo"
       },
       {
         "name": "Aurora Galileo",
@@ -29816,7 +29816,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/25/Aurora_Galileo_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aurora_Galileo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aurora_Galileo"
       },
       {
         "name": "Mirei",
@@ -29833,7 +29833,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/14/Mirei.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mirei"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mirei"
       },
       {
         "name": "Aurora Mirei",
@@ -29850,7 +29850,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/57/Aurora_Mirei_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aurora_Mirei"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aurora_Mirei"
       },
       {
         "name": "Captain Cook",
@@ -29867,7 +29867,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f2/Captain_Cook.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Cook"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Cook"
       },
       {
         "name": "Aurora Captain Cook",
@@ -29884,7 +29884,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d0/Aurora_Captain_Cook_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aurora_Captain_Cook"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aurora_Captain_Cook"
       },
       {
         "name": "Securie",
@@ -29901,7 +29901,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/cf/Securie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Securie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Securie"
       },
       {
         "name": "Halley",
@@ -29922,7 +29922,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/60/Halley.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Halley"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Halley"
       },
       {
         "name": "Party Oracle",
@@ -29939,7 +29939,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fc/Party_Oracle.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Party_Oracle"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Party_Oracle"
       },
       {
         "name": "Party Alchemist",
@@ -29956,7 +29956,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/67/Party_Alchemist.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Party_Alchemist"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Party_Alchemist"
       },
       {
         "name": "Celestial Trio",
@@ -29981,7 +29981,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/da/Celestial_Trio.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Celestial_Trio"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Celestial_Trio"
       },
       {
         "name": "Schalk",
@@ -29994,7 +29994,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e8/Schalk.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Schalk"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Schalk"
       },
       {
         "name": "Pure Slime",
@@ -30011,7 +30011,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f8/Pure_Slime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pure_Slime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pure_Slime"
       },
       {
         "name": "Cute Slime",
@@ -30024,7 +30024,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f1/Cute_Slime_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cute_Slime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cute_Slime"
       },
       {
         "name": "Empress Slime",
@@ -30041,7 +30041,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d2/Empress_Slime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress_Slime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress_Slime"
       },
       {
         "name": "Asmodel",
@@ -30066,7 +30066,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/52/Asmodel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Asmodel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Asmodel"
       },
       {
         "name": "Sister Carmina",
@@ -30083,7 +30083,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/47/Sister_Carmina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sister_Carmina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sister_Carmina"
       },
       {
         "name": "Sosha",
@@ -30100,7 +30100,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2e/Sosha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sosha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sosha"
       },
       {
         "name": "Slime Guardian",
@@ -30117,7 +30117,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/04/Slime_Guardian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Slime_Guardian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Slime_Guardian"
       },
       {
         "name": "Latrina",
@@ -30134,7 +30134,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/22/Latrina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Latrina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Latrina"
       },
       {
         "name": "Narukami",
@@ -30151,7 +30151,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Narukami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Narukami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Narukami"
       },
       {
         "name": "Furia",
@@ -30168,7 +30168,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/05/Furia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Furia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Furia"
       },
       {
         "name": "Coorie",
@@ -30185,7 +30185,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/10/Coorie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Coorie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Coorie"
       },
       {
         "name": "Fuka",
@@ -30202,7 +30202,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/33/Fuka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fuka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fuka"
       },
       {
         "name": "New Fuka",
@@ -30219,7 +30219,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/92/New_Fuka_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/New_Fuka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/New_Fuka"
       },
       {
         "name": "Agatha",
@@ -30236,7 +30236,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a5/Agatha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Agatha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Agatha"
       },
       {
         "name": "Red Moon",
@@ -30261,7 +30261,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fa/Red_Moon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Moon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Moon"
       },
       {
         "name": "Apprentice Emilie",
@@ -30274,7 +30274,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/98/Apprentice_Emilie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Apprentice_Emilie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Apprentice_Emilie"
       },
       {
         "name": "Mage Emilie",
@@ -30291,7 +30291,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Mage_Emilie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mage_Emilie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mage_Emilie"
       },
       {
         "name": "Ball Emilie",
@@ -30308,7 +30308,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0a/Ball_Emilie_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ball_Emilie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ball_Emilie"
       },
       {
         "name": "Archmage Emilie",
@@ -30333,7 +30333,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a5/Archmage_Emilie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Archmage_Emilie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Archmage_Emilie"
       },
       {
         "name": "Nero",
@@ -30350,7 +30350,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ed/Nero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nero"
       },
       {
         "name": "Maestra Nero",
@@ -30367,7 +30367,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b3/Maestra_Nero_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maestra_Nero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maestra_Nero"
       },
       {
         "name": "Mao",
@@ -30384,7 +30384,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/81/Mao.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nero"
       },
       {
         "name": "Maestra Mao",
@@ -30401,7 +30401,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7c/Maestra_Mao_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maestra_Mao"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maestra_Mao"
       },
       {
         "name": "Luluka",
@@ -30418,7 +30418,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/33/Luluka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Luluka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Luluka"
       },
       {
         "name": "Maestra Luluka",
@@ -30435,7 +30435,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f2/Maestra_Luluka_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Maestra_Luluka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Maestra_Luluka"
       },
       {
         "name": "Sterix",
@@ -30452,7 +30452,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/50/Sterix.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sterix"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sterix"
       },
       {
         "name": "Alyssa",
@@ -30473,7 +30473,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9e/Alyssa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alyssa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alyssa"
       },
       {
         "name": "Sahaquiel",
@@ -30498,7 +30498,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c6/Sahaquiel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sahaquiel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sahaquiel"
       },
       {
         "name": "Time Chronos",
@@ -30523,7 +30523,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0b/Time_Chronos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Time_Chronos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Time_Chronos"
       },
       {
         "name": "Sogia",
@@ -30536,7 +30536,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b8/Sogia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sogia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sogia"
       },
       {
         "name": "Minister Cairn",
@@ -30553,7 +30553,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/75/Minister_Cairn.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minister_Cairn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minister_Cairn"
       },
       {
         "name": "Nurse Cairn",
@@ -30567,7 +30567,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ea/Nurse_Cairn_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nurse_Cairn"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nurse_Cairn"
       },
       {
         "name": "PM Demise",
@@ -30584,7 +30584,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8b/PM_Demise.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/PM_Demise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/PM_Demise"
       },
       {
         "name": "Vice Chair Demise",
@@ -30598,7 +30598,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fb/Vice_Chair_Demise_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Vice_Chair_Demise"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Vice_Chair_Demise"
       },
       {
         "name": "Monarda",
@@ -30615,7 +30615,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/eb/Monarda.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Monarda"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Monarda"
       },
       {
         "name": "Hephaestus",
@@ -30640,7 +30640,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/25/Hephaestus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hephaestus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hephaestus"
       },
       {
         "name": "Rosa Canina",
@@ -30657,7 +30657,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d7/Rosa_Canina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rosa_Canina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rosa_Canina"
       },
       {
         "name": "Karen",
@@ -30674,7 +30674,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/71/Karen.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Karen"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Karen"
       },
       {
         "name": "Momiji",
@@ -30691,7 +30691,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Momiji.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Momiji"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Momiji"
       },
       {
         "name": "Harnett",
@@ -30708,7 +30708,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/42/Harnett.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Harnett"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Harnett"
       },
       {
         "name": "Anisha",
@@ -30725,7 +30725,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ab/Anisha.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Anisha"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Anisha"
       },
       {
         "name": "Sound Spirit",
@@ -30742,7 +30742,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/ce/Sound_Spirit.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sound_Spirit"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sound_Spirit"
       },
       {
         "name": "Tanuki Gal",
@@ -30759,7 +30759,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/94/Tanuki_Gal.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tanuki_Gal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tanuki_Gal"
       },
       {
         "name": "Flashy Tanuki Gal",
@@ -30776,7 +30776,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7c/Flashy_Tanuki_Gal_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Flashy_Tanuki_Gal"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Flashy_Tanuki_Gal"
       },
       {
         "name": "Meteor",
@@ -30801,7 +30801,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/99/Meteor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Meteor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Meteor"
       },
       {
         "name": "Aym",
@@ -30826,7 +30826,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/54/Aym.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Aym"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Aym"
       },
       {
         "name": "Tyrano",
@@ -30839,7 +30839,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a0/Tyrano.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tyrano"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tyrano"
       },
       {
         "name": "Mighty Tyrano",
@@ -30856,7 +30856,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Mighty_Tyrano.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mighty_Tyrano"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mighty_Tyrano"
       },
       {
         "name": "Heroic Tyrano",
@@ -30873,7 +30873,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1d/Heroic_Tyrano_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Heroic_Tyrano"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Heroic_Tyrano"
       },
       {
         "name": "Empress Tyrano",
@@ -30898,7 +30898,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ad/Empress_Tyrano.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Empress_Tyrano"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Empress_Tyrano"
       },
       {
         "name": "Tricera",
@@ -30915,7 +30915,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/03/Tricera.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Tricera"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Tricera"
       },
       {
         "name": "Virago Tricera",
@@ -30932,7 +30932,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/18/Virago_Tricera_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virago_Tricera"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virago_Tricera"
       },
       {
         "name": "Ptero",
@@ -30949,7 +30949,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/76/Ptero.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ptero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ptero"
       },
       {
         "name": "Virago Ptero",
@@ -30966,7 +30966,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Virago_Ptero_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virago_Ptero"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virago_Ptero"
       },
       {
         "name": "Ichthyo",
@@ -30983,7 +30983,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8b/Ichthyo.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ichthyo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ichthyo"
       },
       {
         "name": "Virago Ichthyo",
@@ -31000,7 +31000,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/76/Virago_Ichthyo_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virago_Ichthyo"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virago_Ichthyo"
       },
       {
         "name": "Captain Kidd",
@@ -31017,7 +31017,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e9/Captain_Kidd.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Kidd"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Kidd"
       },
       {
         "name": "Raptor",
@@ -31038,7 +31038,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/08/Raptor.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Raptor"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Raptor"
       },
       {
         "name": "Louhi",
@@ -31063,7 +31063,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/51/Louhi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Louhi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Louhi"
       },
       {
         "name": "Jodie Legend",
@@ -31088,7 +31088,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/12/Jodie_Legend.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jodie_Legend"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jodie_Legend"
       },
       {
         "name": "Sylvio",
@@ -31101,7 +31101,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7b/Sylvio.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sylvio"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sylvio"
       },
       {
         "name": "Damilia",
@@ -31118,7 +31118,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/22/Damilia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Damilia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Damilia"
       },
       {
         "name": "Holiday Damilia",
@@ -31131,7 +31131,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1f/Holiday_Damilia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Holiday_Damilia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Holiday_Damilia"
       },
       {
         "name": "Speranza",
@@ -31148,7 +31148,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/98/Speranza.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Speranza"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Speranza"
       },
       {
         "name": "Horae",
@@ -31173,7 +31173,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/53/Horae.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Horae"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Horae"
       },
       {
         "name": "Pietra",
@@ -31190,7 +31190,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a6/Pietra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pietra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pietra"
       },
       {
         "name": "Caprice",
@@ -31207,7 +31207,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ea/Caprice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Caprice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Caprice"
       },
       {
         "name": "Mikaity",
@@ -31224,7 +31224,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/81/Mikaity.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mikaity"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mikaity"
       },
       {
         "name": "Lynette",
@@ -31241,7 +31241,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Lynette.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lynette"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lynette"
       },
       {
         "name": "Irene",
@@ -31258,7 +31258,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/40/Irene.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Irene"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Irene"
       },
       {
         "name": "Peria",
@@ -31275,7 +31275,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/25/Peria.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Peria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Peria"
       },
       {
         "name": "Fiendish Peria",
@@ -31292,7 +31292,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/68/Fiendish_Peria_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fiendish_Peria"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fiendish_Peria"
       },
       {
         "name": "Lisay",
@@ -31313,7 +31313,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Lisay.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lisay"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lisay"
       },
       {
         "name": "Ludovica",
@@ -31338,7 +31338,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b5/Ludovica.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ludovica"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ludovica"
       },
       {
         "name": "Turbo Aludra",
@@ -31363,7 +31363,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Turbo_Aludra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Turbo_Aludra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Turbo_Aludra"
       },
       {
         "name": "Rookie Hatsune",
@@ -31376,7 +31376,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e9/Rookie_Hatsune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Rookie_Hatsune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Rookie_Hatsune"
       },
       {
         "name": "Ninja Hatsune",
@@ -31393,7 +31393,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c1/Ninja_Hatsune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Ninja_Hatsune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Ninja_Hatsune"
       },
       {
         "name": "Crimson Hatsune",
@@ -31410,7 +31410,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c5/Crimson_Hatsune_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crimson_Hatsune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crimson_Hatsune"
       },
       {
         "name": "Master Hatsune",
@@ -31435,7 +31435,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/77/Master_Hatsune.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Master_Hatsune"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Master_Hatsune"
       },
       {
         "name": "Water Ninja",
@@ -31452,7 +31452,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/63/Water_Ninja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Water_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Water_Ninja"
       },
       {
         "name": "Secret Water Ninja",
@@ -31469,7 +31469,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/66/Secret_Water_Ninja_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Secret_Water_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Secret_Water_Ninja"
       },
       {
         "name": "Fire Ninja",
@@ -31486,7 +31486,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0e/Fire_Ninja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fire_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fire_Ninja"
       },
       {
         "name": "Secret Fire Ninja",
@@ -31503,7 +31503,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Secret_Fire_Ninja_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Secret_Fire_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Secret_Fire_Ninja"
       },
       {
         "name": "Wind Ninja",
@@ -31520,7 +31520,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0c/Wind_Ninja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Wind_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Wind_Ninja"
       },
       {
         "name": "Secret Wind Ninja",
@@ -31537,7 +31537,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/95/Secret_Wind_Ninja_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Secret_Wind_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Secret_Wind_Ninja"
       },
       {
         "name": "Yuu",
@@ -31554,7 +31554,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/34/Yuu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yuu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yuu"
       },
       {
         "name": "Yami",
@@ -31575,7 +31575,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/30/Yami.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yami"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yami"
       },
       {
         "name": "Scully",
@@ -31592,7 +31592,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3f/Scully.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Scully"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Scully"
       },
       {
         "name": "Akari",
@@ -31617,7 +31617,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7d/Akari.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Akari"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Akari"
       },
       {
         "name": "Kyklos",
@@ -31630,7 +31630,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/32/Kyklos.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kyklos"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kyklos"
       },
       {
         "name": "Sexy Summer Pixie",
@@ -31647,7 +31647,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/66/Sexy_Summer_Pixie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sexy_Summer_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sexy_Summer_Pixie"
       },
       {
         "name": "Cute Pixie",
@@ -31660,7 +31660,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d8/Cute_Pixie_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cute_Pixie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cute_Pixie"
       },
       {
         "name": "Havfrue",
@@ -31677,7 +31677,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7d/Havfrue.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Havfrue"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Havfrue"
       },
       {
         "name": "Enosea",
@@ -31702,7 +31702,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6c/Enosea.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Enosea"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Enosea"
       },
       {
         "name": "Merrow",
@@ -31719,7 +31719,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/80/Merrow.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Merrow"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Merrow"
       },
       {
         "name": "Sufay",
@@ -31736,7 +31736,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Sufay.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sufay"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sufay"
       },
       {
         "name": "Oomin",
@@ -31753,7 +31753,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/98/Oomin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Oomin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Oomin"
       },
       {
         "name": "Marguerite",
@@ -31778,7 +31778,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Marguerite.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Marguerite"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Marguerite"
       },
       {
         "name": "Lorayne",
@@ -31795,7 +31795,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/94/Lorayne.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lorayne"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lorayne"
       },
       {
         "name": "Eleanora",
@@ -31812,7 +31812,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/31/Eleanora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Eleanora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Eleanora"
       },
       {
         "name": "Lilliel",
@@ -31829,7 +31829,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e4/Lilliel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lilliel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lilliel"
       },
       {
         "name": "Restful Lilliel",
@@ -31846,7 +31846,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a0/Restful_Lilliel_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Restful_Lilliel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Restful_Lilliel"
       },
       {
         "name": "DIY Ninja",
@@ -31863,7 +31863,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/96/DIY_Ninja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/DIY_Ninja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/DIY_Ninja"
       },
       {
         "name": "Alvina",
@@ -31888,7 +31888,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7e/Alvina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Alvina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Alvina"
       },
       {
         "name": "Lu",
@@ -31901,7 +31901,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/58/Lu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lu"
       },
       {
         "name": "Soloist Lu",
@@ -31918,7 +31918,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1c/Soloist_Lu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soloist_Lu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soloist_Lu"
       },
       {
         "name": "Formal Lu",
@@ -31935,7 +31935,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/ce/Formal_Lu_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Formal_Lu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Formal_Lu"
       },
       {
         "name": "Blessed Lu",
@@ -31960,7 +31960,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9a/Blessed_Lu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Blessed_Lu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Blessed_Lu"
       },
       {
         "name": "Virtuoso Lu",
@@ -31977,7 +31977,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/88/Virtuoso_Lu_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virtuoso_Lu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virtuoso_Lu"
       },
       {
         "name": "Feli",
@@ -31994,7 +31994,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/ba/Feli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Feli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Feli"
       },
       {
         "name": "Melody Feli",
@@ -32011,7 +32011,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/47/Melody_Feli_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melody_Feli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melody_Feli"
       },
       {
         "name": "Caro",
@@ -32028,7 +32028,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/62/Caro.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Caro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Caro"
       },
       {
         "name": "Melody Caro",
@@ -32045,7 +32045,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/42/Melody_Caro_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melody_Caro"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melody_Caro"
       },
       {
         "name": "Timi",
@@ -32062,7 +32062,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4b/Timi.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Timi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Timi"
       },
       {
         "name": "Melody Timi",
@@ -32079,7 +32079,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fd/Melody_Timi_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Melody_Timi"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Melody_Timi"
       },
       {
         "name": "Fermata",
@@ -32096,7 +32096,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bc/Fermata.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Fermata"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Fermata"
       },
       {
         "name": "Irisa",
@@ -32117,7 +32117,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d1/Irisa.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Irisa"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Irisa"
       },
       {
         "name": "Biscotti",
@@ -32142,7 +32142,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1c/Biscotti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Biscotti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Biscotti"
       },
       {
         "name": "Theodora",
@@ -32167,7 +32167,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/ed/Theodora.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Theodora"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Theodora"
       },
       {
         "name": "Thviti",
@@ -32180,7 +32180,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/05/Thviti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Thviti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Thviti"
       },
       {
         "name": "Gelgja",
@@ -32197,7 +32197,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d6/Gelgja.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gelgja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gelgja"
       },
       {
         "name": "Divine Gelgja",
@@ -32210,7 +32210,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e7/Divine_Gelgja_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Divine_Gelgja"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Divine_Gelgja"
       },
       {
         "name": "Gjoll",
@@ -32227,7 +32227,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f5/Gjoll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Gjoll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Gjoll"
       },
       {
         "name": "True Wolf Skoll",
@@ -32252,7 +32252,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a1/True_Wolf_Skoll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/True_Wolf_Skoll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/True_Wolf_Skoll"
       },
       {
         "name": "Andordice",
@@ -32269,7 +32269,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/19/Andordice.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Andordice"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Andordice"
       },
       {
         "name": "Njord",
@@ -32286,7 +32286,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9d/Njord.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Njord"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Njord"
       },
       {
         "name": "Nerthus",
@@ -32303,7 +32303,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/92/Nerthus.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nerthus"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nerthus"
       },
       {
         "name": "Soiree",
@@ -32320,7 +32320,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/70/Soiree.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Soiree"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Soiree"
       },
       {
         "name": "Elsie",
@@ -32337,7 +32337,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/84/Elsie.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Elsie"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Elsie"
       },
       {
         "name": "Neena",
@@ -32354,7 +32354,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/99/Neena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Neena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Neena"
       },
       {
         "name": "Mage Neena",
@@ -32371,7 +32371,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4f/Mage_Neena_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mage_Neena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mage_Neena"
       },
       {
         "name": "Machina",
@@ -32388,7 +32388,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bd/Machina.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Machina"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Machina"
       },
       {
         "name": "Helka",
@@ -32413,7 +32413,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ab/Helka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Helka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Helka"
       },
       {
         "name": "Senna",
@@ -32438,7 +32438,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5e/Senna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Senna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Senna"
       },
       {
         "name": "Mikli",
@@ -32451,7 +32451,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/77/Mikli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mikli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mikli"
       },
       {
         "name": "Pilot Mikli",
@@ -32468,7 +32468,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Pilot_Mikli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pilot_Mikli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pilot_Mikli"
       },
       {
         "name": "Detective Mikli",
@@ -32485,7 +32485,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b5/Detective_Mikli_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Detective_Mikli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Detective_Mikli"
       },
       {
         "name": "Captain Mikli",
@@ -32510,7 +32510,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/69/Captain_Mikli.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Captain_Mikli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Captain_Mikli"
       },
       {
         "name": "Commander Mikli",
@@ -32527,7 +32527,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f6/Commander_Mikli_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Commander_Mikli"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Commander_Mikli"
       },
       {
         "name": "Krull",
@@ -32544,7 +32544,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/60/Krull.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Krull"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Krull"
       },
       {
         "name": "Sky-High Krull",
@@ -32561,7 +32561,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Sky-High_Krull_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sky-High_Krull"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sky-High_Krull"
       },
       {
         "name": "Strahler",
@@ -32578,7 +32578,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/87/Strahler.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Strahler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Strahler"
       },
       {
         "name": "Sky-High Strahler",
@@ -32595,7 +32595,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e3/Sky-High_Strahler_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sky-High_Strahler"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sky-High_Strahler"
       },
       {
         "name": "Effole",
@@ -32612,7 +32612,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/47/Effole.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Effole"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Effole"
       },
       {
         "name": "Sky-High Effole",
@@ -32629,7 +32629,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1d/Sky-High_Effole_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sky-High_Effole"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sky-High_Effole"
       },
       {
         "name": "Jorna",
@@ -32650,7 +32650,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/49/Jorna.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Jorna"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Jorna"
       },
       {
         "name": "Auster",
@@ -32675,7 +32675,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/25/Auster.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Auster"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Auster"
       },
       {
         "name": "Archwitch Ymir",
@@ -32700,7 +32700,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/79/Archwitch_Ymir.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Archwitch_Ymir"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Archwitch_Ymir"
       },
       {
         "name": "Aster",
@@ -32721,7 +32721,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/86/Aster.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Aster"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Aster"
       },
       {
         "name": "Coach Jigan",
@@ -32734,7 +32734,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5a/Coach_Jigan_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Coach_Jigan"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Coach_Jigan"
       },
       {
         "name": "Coucke",
@@ -32747,7 +32747,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/ca/Coucke.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Coucke"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Coucke"
       },
       {
         "name": "Minister Jigan",
@@ -32764,7 +32764,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b3/Minister_Jigan.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Minister_Jigan"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Minister_Jigan"
       },
       {
         "name": "Minister Prikat",
@@ -32781,7 +32781,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6b/Minister_Prikat.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Minister_Prikat"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Minister_Prikat"
       },
       {
         "name": "Prof. Prikat",
@@ -32794,7 +32794,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/90/Prof._Prikat_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Prof._Prikat"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Prof._Prikat"
       },
       {
         "name": "Stella",
@@ -32815,7 +32815,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/31/Stella.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Stella"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Stella"
       },
       {
         "name": "Trasel",
@@ -32832,7 +32832,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7a/Trasel.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Trasel"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Trasel"
       },
       {
         "name": "Tula",
@@ -32849,7 +32849,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e8/Tula.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Tula"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Tula"
       },
       {
         "name": "Artemisia",
@@ -32874,7 +32874,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/34/Artemisia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Artemisia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Artemisia"
       },
       {
         "name": "Ginette",
@@ -32891,7 +32891,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/49/Ginette.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Ginette"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Ginette"
       },
       {
         "name": "Liese",
@@ -32908,7 +32908,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/23/Liese.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Liese"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Liese"
       },
       {
         "name": "Minette",
@@ -32925,7 +32925,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Minette.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Minette"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Minette"
       },
       {
         "name": "Miranda",
@@ -32942,7 +32942,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1d/Miranda.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Miranda"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Miranda"
       },
       {
         "name": "Nimble Miranda",
@@ -32959,7 +32959,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f9/Nimble_Miranda_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Nimble_Miranda"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Nimble_Miranda"
       },
       {
         "name": "Yunice",
@@ -32984,7 +32984,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/05/Yunice.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Yunice"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Yunice"
       },
       {
         "name": "Zhuyin",
@@ -33001,7 +33001,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0a/Zhuyin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Zhuyin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Zhuyin"
       },
       {
         "name": "Sungod Maiden",
@@ -33018,7 +33018,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f9/Sungod_Maiden_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sungod_Maiden"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sungod_Maiden"
       },
       {
         "name": "Catherine",
@@ -33031,7 +33031,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a5/Catherine.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Catherine"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Catherine"
       },
       {
         "name": "Pilot Crusch",
@@ -33048,7 +33048,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6f/Crusch.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Crusch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Crusch"
       },
       {
         "name": "Red Hood Crusch",
@@ -33065,7 +33065,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4f/Red_Hood_Crusch_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Red_Hood_Crusch"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Red_Hood_Crusch"
       },
       {
         "name": "Lenalee",
@@ -33090,7 +33090,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2b/Lenalee.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lenalee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lenalee"
       },
       {
         "name": "Virtuous Lenalee",
@@ -33107,7 +33107,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f4/Virtuous_Lenalee_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Virtuous_Lenalee"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Virtuous_Lenalee"
       },
       {
         "name": "Feuille",
@@ -33124,7 +33124,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/13/Feuille.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Feuille"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Feuille"
       },
       {
         "name": "Protector Feuille",
@@ -33141,7 +33141,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d5/Protector_Feuille_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Protector_Feuille"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Protector_Feuille"
       },
       {
         "name": "Roll",
@@ -33158,7 +33158,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/15/Roll.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Roll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Roll"
       },
       {
         "name": "Protector Roll",
@@ -33175,7 +33175,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/78/Protector_Roll_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Protector_Roll"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Protector_Roll"
       },
       {
         "name": "Nonon",
@@ -33192,7 +33192,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2b/Nonon.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nonon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nonon"
       },
       {
         "name": "Protector Nonon",
@@ -33209,7 +33209,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6a/Protector_Nonon_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Protector_Nonon"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Protector_Nonon"
       },
       {
         "name": "Dariel",
@@ -33230,7 +33230,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f1/Dariel.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Dariel"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Dariel"
       },
       {
         "name": "Amelia",
@@ -33255,7 +33255,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d3/Amelia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Amelia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Amelia"
       },
       {
         "name": "Halloween Gem",
@@ -33268,7 +33268,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Halloween_Gem.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Halloween_Gem"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Halloween_Gem"
       },
       {
         "name": "Halloween Herb",
@@ -33285,7 +33285,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e5/Halloween_Herb.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Halloween_Herb"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Halloween_Herb"
       },
       {
         "name": "Halloween Astral",
@@ -33302,7 +33302,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e6/Halloween_Astral.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Halloween_Astral"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Halloween_Astral"
       },
       {
         "name": "Mummy Astral",
@@ -33315,7 +33315,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/51/Mummy_Astral_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Mummy_Astral"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Mummy_Astral"
       },
       {
         "name": "Saon",
@@ -33332,7 +33332,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a8/Saon.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Saon"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Saon"
       },
       {
         "name": "Ninril",
@@ -33357,7 +33357,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c4/Ninril.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Ninril"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Ninril"
       },
       {
         "name": "Francesca",
@@ -33378,7 +33378,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1b/Francesca.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Francesca"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Francesca"
       },
       {
         "name": "Monstera",
@@ -33399,7 +33399,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b1/Monstera.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Monstera"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Monstera"
       },
       {
         "name": "Holo",
@@ -33416,7 +33416,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2c/Holo.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Holo"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Holo"
       },
       {
         "name": "Dr. Shennong",
@@ -33441,7 +33441,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/eb/Dr._Shennong.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Dr._Shennong"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Dr._Shennong"
       },
       {
         "name": "Suoh",
@@ -33458,7 +33458,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c2/Suoh.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Suoh"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Suoh"
       },
       {
         "name": "Orlaya Mummy",
@@ -33475,7 +33475,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6f/Orlaya_Mummy.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Orlaya_Mummy"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Orlaya_Mummy"
       },
       {
         "name": "Halloween Sherry",
@@ -33492,7 +33492,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Halloween_Sherry.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Halloween_Sherry"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Halloween_Sherry"
       },
       {
         "name": "Carmen",
@@ -33509,7 +33509,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/65/Carmen.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Carmen"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Carmen"
       },
       {
         "name": "Diva Carmen",
@@ -33526,7 +33526,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4d/Diva_Carmen_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Diva_Carmen"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Diva_Carmen"
       },
       {
         "name": "Ryphia",
@@ -33551,7 +33551,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bc/Ryphia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Ryphia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Ryphia"
       },
       {
         "name": "Kokone",
@@ -33564,7 +33564,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/24/Kokone.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Kokone"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Kokone"
       },
       {
         "name": "Arsia",
@@ -33581,7 +33581,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/86/Arsia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Arsia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Arsia"
       },
       {
         "name": "Sexy Arsia",
@@ -33598,7 +33598,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a3/Sexy_Arsia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sexy_Arsia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sexy_Arsia"
       },
       {
         "name": "Shanlian",
@@ -33623,7 +33623,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/3c/Shanlian.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Shanlian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Shanlian"
       },
       {
         "name": "Doctor Shanlian",
@@ -33640,7 +33640,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/ab/Doctor_Shanlian_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Doctor_Shanlian"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Doctor_Shanlian"
       },
       {
         "name": "Linlin",
@@ -33657,7 +33657,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/03/Linlin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Linlin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Linlin"
       },
       {
         "name": "Adroit Linlin",
@@ -33674,7 +33674,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Adroit_Linlin_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Adroit_Linlin"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Adroit_Linlin"
       },
       {
         "name": "Amalia",
@@ -33691,7 +33691,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9b/Amalia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Amalia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Amalia"
       },
       {
         "name": "Adroit Amalia",
@@ -33708,7 +33708,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d5/Adroit_Amalia_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Adroit_Amalia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Adroit_Amalia"
       },
       {
         "name": "Greta",
@@ -33725,7 +33725,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/20/Greta.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Greta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Greta"
       },
       {
         "name": "Adroit Agreta",
@@ -33742,7 +33742,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5c/Adroit_Agreta_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Adroit_Agreta"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Adroit_Agreta"
       },
       {
         "name": "Olivia",
@@ -33763,7 +33763,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f3/Olivia.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Olivia"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Olivia"
       },
       {
         "name": "Claudia",
@@ -33788,7 +33788,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/34/Claudia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Claudia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Claudia"
       },
       {
         "name": "Silver Bell",
@@ -33809,7 +33809,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d5/Silver_Bell.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Silver_Bell"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Silver_Bell"
       },
       {
         "name": "Holy Whitecloth",
@@ -33834,7 +33834,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/03/Holy_Whitecloth.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Holy_Whitecloth"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Holy_Whitecloth"
       },
       {
         "name": "Nehrin",
@@ -33847,7 +33847,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7b/Nehrin.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Nehrin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Nehrin"
       },
       {
         "name": "Angry Nehrin",
@@ -33860,7 +33860,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/83/Angry_Nehrin_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Angry_Nehrin"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Angry_Nehrin"
       },
       {
         "name": "Minister Kyula",
@@ -33877,7 +33877,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9f/Minister_Kyula.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minister_Kyula"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minister_Kyula"
       },
       {
         "name": "Beautifier Kyula",
@@ -33890,7 +33890,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/66/Beautifier_Kyula_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beautifier_Kyula"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beautifier_Kyula"
       },
       {
         "name": "Minister Kyulu",
@@ -33907,7 +33907,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Minister_Kyulu.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Minister_Kyulu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Minister_Kyulu"
       },
       {
         "name": "Beautifier Kyulu",
@@ -33920,7 +33920,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f3/Beautifier_Kyulu_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Beautifier_Kyulu"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Beautifier_Kyulu"
       },
       {
         "name": "Sister Meemori",
@@ -33937,7 +33937,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a3/Sister_Meemori.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Sister_Meemori"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Sister_Meemori"
       },
       {
         "name": "Yurahime",
@@ -33962,7 +33962,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fc/Yurahime.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Yurahime"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Yurahime"
       },
       {
         "name": "Whale",
@@ -33979,7 +33979,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c6/Whale.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Whale"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Whale"
       },
       {
         "name": "Hirluka",
@@ -34000,7 +34000,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a8/Hirluka.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Hirluka"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Hirluka"
       },
       {
         "name": "Mariest",
@@ -34021,7 +34021,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/22/Mariest.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Mariest"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Mariest"
       },
       {
         "name": "Lisbeth",
@@ -34046,7 +34046,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c7/Lisbeth.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Lisbeth"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Lisbeth"
       },
       {
         "name": "Asto Vidatu",
@@ -34063,7 +34063,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/1c/Asto_Vidatu.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Asto_Vidatu"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Asto_Vidatu"
       },
       {
         "name": "Eir Maid",
@@ -34080,7 +34080,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/7f/Eir_Maid.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Eir_Maid"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Eir_Maid"
       },
       {
         "name": "Temari",
@@ -34097,7 +34097,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/02/Temari.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Temari"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Temari"
       },
       {
         "name": "Autumn Temari",
@@ -34114,7 +34114,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/93/Autumn_Temari_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Autumn_Temari"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Autumn_Temari"
       },
       {
         "name": "Illumi",
@@ -34131,7 +34131,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/52/Illumi.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Illumi"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Illumi"
       },
       {
         "name": "Popple",
@@ -34156,7 +34156,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/9f/Popple.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Popple"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Popple"
       },
       {
         "name": "Haagenti",
@@ -34181,7 +34181,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/95/Haagenti.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Haagenti"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Haagenti"
       },
       {
         "name": "Luana",
@@ -34194,7 +34194,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Luana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Luana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Luana"
       },
       {
         "name": "Cook Luana",
@@ -34211,7 +34211,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/73/Cook_Luana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Cook_Luana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Cook_Luana"
       },
       {
         "name": "Chef Luana",
@@ -34236,7 +34236,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8e/Chef_Luana.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chef_Luana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chef_Luana"
       },
       {
         "name": "Waitress Luana",
@@ -34253,7 +34253,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0f/Waitress_Luana_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Waitress_Luana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Waitress_Luana"
       },
       {
         "name": "Head Chef Luana",
@@ -34270,7 +34270,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/01/Head_Chef_Luana_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Head_Chef_Luana"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Head_Chef_Luana"
       },
       {
         "name": "Chloe",
@@ -34287,7 +34287,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f2/Chloe.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Chloe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Chloe"
       },
       {
         "name": "Banquet Chloe",
@@ -34304,7 +34304,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b5/Banquet_Chloe_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Banquet_Chloe"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Banquet_Chloe"
       },
       {
         "name": "Lena",
@@ -34321,7 +34321,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b9/Lena.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Lena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Lena"
       },
       {
         "name": "Banquet Lena",
@@ -34338,7 +34338,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/49/Banquet_Lena_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Banquet_Lena"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Banquet_Lena"
       },
       {
         "name": "Leviatan",
@@ -34355,7 +34355,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/00/Leviatan.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Leviatan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Leviatan"
       },
       {
         "name": "Banquet Leviatan",
@@ -34372,7 +34372,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a8/Banquet_Leviatan_H.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Banquet_Leviatan"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Banquet_Leviatan"
       },
       {
         "name": "Umeko",
@@ -34393,7 +34393,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b2/Umeko.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Umeko"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Umeko"
       },
       {
         "name": "Pres Calamity",
@@ -34418,7 +34418,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b3/Pres_Calamity.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Pres_Calamity"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Pres_Calamity"
       },
       {
         "name": "Emp Cleopatra",
@@ -34443,7 +34443,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e5/Emp_Cleopatra.png",
-        "link": "http://valkyriecrusade.wikia.com/wiki/Emp_Cleopatra"
+        "link": "http://valkyriecrusade.fandom.com/wiki/Emp_Cleopatra"
       },
       {
         "name": "Cochineal",
@@ -34456,7 +34456,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/54/Cochineal.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Cochineal"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Cochineal"
       },
       {
         "name": "Agent Koh",
@@ -34473,7 +34473,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/32/Agent_Koh.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Agent_Koh"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Agent_Koh"
       },
       {
         "name": "Christmas Koh",
@@ -34486,7 +34486,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a3/Christmas_Koh_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Christmas_Koh"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Christmas_Koh"
       },
       {
         "name": "Azalea",
@@ -34503,7 +34503,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/bb/Azalea.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Azalea"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Azalea"
       },
       {
         "name": "Itsuki",
@@ -34528,7 +34528,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8d/Itsuki.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Itsuki"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Itsuki"
       },
       {
         "name": "Rudy",
@@ -34545,7 +34545,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e2/Rudy.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Rudy"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Rudy"
       },
       {
         "name": "Yule",
@@ -34562,7 +34562,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0c/Yule.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Yule"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Yule"
       },
       {
         "name": "Croissant",
@@ -34579,7 +34579,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/a0/Croissant.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Croissant"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Croissant"
       },
       {
         "name": "Platy",
@@ -34604,7 +34604,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/Platy.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Platy"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Platy"
       },
       {
         "name": "Dark Audrey",
@@ -34621,7 +34621,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/48/Dark_Audrey.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Dark_Audrey"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Dark_Audrey"
       },
       {
         "name": "Hero Audrey",
@@ -34638,7 +34638,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/54/Hero_Audrey_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Hero_Audrey"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Hero_Audrey"
       },
       {
         "name": "Saya",
@@ -34655,7 +34655,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/ce/Saya.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Saya"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Saya"
       },
       {
         "name": "Lily",
@@ -34672,7 +34672,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/0/0a/Lily.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Lily"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Lily"
       },
       {
         "name": "Traytis",
@@ -34689,7 +34689,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/58/Traytis.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Traytis"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Traytis"
       },
       {
         "name": "Christmas Len",
@@ -34714,7 +34714,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/2f/Christmas_Len.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Christmas_Len"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Christmas_Len"
       },
       {
         "name": "Disk Jockey",
@@ -34731,7 +34731,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e9/Disk_Jockey.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Disk_Jockey"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Disk_Jockey"
       },
       {
         "name": "Ibuki",
@@ -34756,7 +34756,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/75/Ibuki.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Ibuki"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Ibuki"
       },
       {
         "name": "Holy Night Hades",
@@ -34781,7 +34781,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/2/24/Holy_Night_Hades.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Holy_Night_Hades"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Holy_Night_Hades"
       },
       {
         "name": "Sazanami",
@@ -34794,7 +34794,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/dc/Sazanami.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sazanami"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sazanami"
       },
       {
         "name": "Aboro",
@@ -34811,7 +34811,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/6/6d/Aboro.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Aboro"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Aboro"
       },
       {
         "name": "Sexy Aboro",
@@ -34828,7 +34828,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/71/Sexy_Aboro_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sexy_Aboro"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sexy_Aboro"
       },
       {
         "name": "Akebono",
@@ -34853,7 +34853,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/8c/Akebono.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Akebono"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Akebono"
       },
       {
         "name": "Sunrise Akebono",
@@ -34870,7 +34870,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e4/Sunrise_Akebono_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sunrise_Akebono"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sunrise_Akebono"
       },
       {
         "name": "Nagi",
@@ -34891,7 +34891,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/db/Nagi.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Nagi"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Nagi"
       },
       {
         "name": "Hatsuharu",
@@ -34908,7 +34908,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/f3/Hatsuharu.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Hatsuharu"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Hatsuharu"
       },
       {
         "name": "Sunray Hatsuharu",
@@ -34925,7 +34925,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/be/Sunray_Hatsuharu_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sunray_Hatsuharu"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sunray_Hatsuharu"
       },
       {
         "name": "Nanakusa",
@@ -34942,7 +34942,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/b/b0/Nanakusa.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Nanakusa"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Nanakusa"
       },
       {
         "name": "Sunray Nanakusa",
@@ -34959,7 +34959,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/7/75/Sunray_Nanakusa_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sunray_Nanakusa"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sunray_Nanakusa"
       },
       {
         "name": "Suzu",
@@ -34976,7 +34976,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/18/Suzu.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Suzu"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Suzu"
       },
       {
         "name": "Sunray Suzu",
@@ -34993,7 +34993,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d3/Sunray_Suzu_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Sunray_Suzu"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Sunray_Suzu"
       },
       {
         "name": "Hazuki",
@@ -35018,7 +35018,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/97/Hazuki.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Hazuki"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Hazuki"
       },
       {
         "name": "Aquavera",
@@ -35035,7 +35035,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/f/fe/Aquavera.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Aquavera"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Aquavera"
       },
       {
         "name": "Lonely Nagatsuki",
@@ -35060,7 +35060,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/1/16/Lonely_Nagatsuki.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Lonely_Nagatsuki"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Lonely_Nagatsuki"
       },
       {
         "name": "Mauve",
@@ -35077,7 +35077,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/4/4e/Mauve.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Mauve"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Mauve"
       },
       {
         "name": "Solferino",
@@ -35094,7 +35094,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/a/af/Solferino.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Solferino"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Solferino"
       },
       {
         "name": "General Sumire",
@@ -35119,7 +35119,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/82/General_Sumire.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/General_Sumire"
+        "link": "https://valkyriecrusade.fandom.com/wiki/General_Sumire"
       },
       {
         "name": "Disaster",
@@ -35152,7 +35152,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e2/Disaster.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Disaster"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Disaster"
       },
       {
         "name": "Bestia",
@@ -35181,7 +35181,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/d/d3/Bestia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Bestia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Bestia"
       },
       {
         "name": "Evaughn",
@@ -35210,7 +35210,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e8/Evaughn.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Evaughn"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Evaughn"
       },
       {
         "name": "Greeme",
@@ -35239,7 +35239,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5a/Greeme.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Greeme"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Greeme"
       },
       {
         "name": "Teaspoon ",
@@ -35256,7 +35256,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/9/92/Teaspoon.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Teaspoon"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Teaspoon"
       },
       {
         "name": "Hermia ",
@@ -35289,7 +35289,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/30/Hermia.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Hermia"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Hermia"
       },
       {
         "name": "Lapfel",
@@ -35306,7 +35306,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5a/Lapfel.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Lapfel"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Lapfel"
       },
       {
         "name": "Maek",
@@ -35323,7 +35323,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/5/5f/Maek.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Maek"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Maek"
       },
       {
         "name": "Dressy Maek",
@@ -35340,7 +35340,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/e/e7/Dressy_Maek_H.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Dressy_Maek"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Dressy_Maek"
       },
       {
         "name": "Nine Tails ",
@@ -35365,7 +35365,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/8/83/Nine_Tails.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Nine_Tails"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Nine_Tails"
       },
       {
         "name": "Quinty",
@@ -35382,7 +35382,7 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/3/31/Quinty.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Quinty"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Quinty"
       },
       {
         "name": "Watanuki",
@@ -35399,6 +35399,6 @@
           }
         ],
         "image": "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c9/Watanuki.png",
-        "link": "https://valkyriecrusade.wikia.com/wiki/Watanuki"
+        "link": "https://valkyriecrusade.fandom.com/wiki/Watanuki"
       }
     ]


### PR DESCRIPTION
wikia changed the domain of our wiki to "fandom.com". For now it doesn't affect image locations.